### PR TITLE
Add support for Rise Cache

### DIFF
--- a/rise-storage/demo.html
+++ b/rise-storage/demo.html
@@ -4,7 +4,7 @@
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
   <title>rise-storage Demo</title>
 
-  <script src="../../webcomponentsjs/webcomponents.js"></script>
+  <script src="/components/webcomponentsjs/webcomponents.js"></script>
   <link rel="import" href="rise-storage.html">
 
 </head>

--- a/rise-storage/index.html
+++ b/rise-storage/index.html
@@ -2,9 +2,9 @@
 <html>
 <head>
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-  <script src="../../webcomponentsjs/webcomponents.js"></script>
-  <link rel="import" href="../../polymer/polymer.html">
-  <link rel="import" href="../../core-component-page/core-component-page.html">
+  <script src="/components/webcomponentsjs/webcomponents.js"></script>
+  <link rel="import" href="/components/polymer/polymer.html">
+  <link rel="import" href="/components/core-component-page/core-component-page.html">
 
 </head>
 <body unresolved>

--- a/rise-storage/rise-storage.html
+++ b/rise-storage/rise-storage.html
@@ -1,5 +1,5 @@
-<link rel="import" href="../../polymer/polymer.html">
-<link rel="import" href="../../core-ajax/core-ajax.html">
+<link rel="import" href="/components/polymer/polymer.html">
+<link rel="import" href="/components/core-ajax/core-ajax.html">
 
 <!--
 The `rise-storage` element retrieves URLs of files stored in Rise Storage.
@@ -47,12 +47,17 @@ You can trigger a request explicitly by calling `go` on the element.
 -->
 <polymer-element name="rise-storage" attributes="companyId folder fileName folderRefresh">
   <template>
-    <core-ajax id="ajax"
+    <core-ajax id="storage"
       url="{{url}}"
       handleAs="json"
-      on-core-response="{{handleResponse}}"
-      on-core-error="{{handleError}}"
-      auto>
+      on-core-response="{{handleStorageResponse}}"
+      on-core-error="{{handleStorageError}}">
+    </core-ajax>
+    <core-ajax id="ping"
+      url="http://localhost:9494/ping?callback=handlePingResponse"
+      handleAs="text"
+      on-core-response="{{handlePingResponse}}"
+      on-core-error="{{handlePingError}}">
     </core-ajax>
   </template>
 
@@ -118,6 +123,15 @@ You can trigger a request explicitly by calling `go` on the element.
        */
       url: "",
 
+       /**
+       * Whether or not Rise Cache is running.
+       *
+       * @property isCacheRunning
+       * @type boolean
+       * @default false
+       */
+      isCacheRunning: false,
+
       ready: function() {
         this.setUrl();
       },
@@ -146,7 +160,7 @@ You can trigger a request explicitly by calling `go` on the element.
           this.url = url;
         }
 
-        this.startTimer();
+        this.$.ping.go();
       },
 
       startTimer: function() {
@@ -156,7 +170,7 @@ You can trigger a request explicitly by calling `go` on the element.
 
           if (!isNaN(this.folderRefresh) && this.folderRefresh !== 0) {
             this.job("refresh", function() {
-              this.go();
+              this.$.ping.go();
               this.startTimer();
             }, this.folderRefresh * 1000);
           }
@@ -175,8 +189,9 @@ You can trigger a request explicitly by calling `go` on the element.
         this.setUrl();
       },
 
-      handleResponse: function(e, resp) {
-        var urls = [];
+      handleStorageResponse: function(e, resp) {
+        var self = this,
+          urls = [];
 
         // Send back array of URLs.
         if (resp && resp.response && resp.response.items) {
@@ -184,22 +199,51 @@ You can trigger a request explicitly by calling `go` on the element.
             // Check that this is not the folder itself.
             if (elem.contentType && elem.contentType !== "text/plain") {
               if (elem.mediaLink) {
-                urls.push(elem.mediaLink);
+                if (self.isCacheRunning) {
+                  urls.push("http://localhost:9494/?url=" + escape(elem.mediaLink));
+                }
+                else {
+                  urls.push(elem.mediaLink);
+                }
               }
             }
           });
         }
         else if (resp && resp.response && resp.response.mediaLink) {
-          urls.push(resp.response.mediaLink);
+          if (this.isCacheRunning) {
+            urls.push("http://localhost:9494/?url=" + escape(resp.response.mediaLink));
+          }
+          else {
+            urls.push(resp.response.mediaLink);
+          }
         }
 
+        this.startTimer();
         this.fire("rise-storage-response", urls);
       },
 
-      handleError: function(e, resp) {
-        console.log("Error: " + resp.xhr.status + " " + resp.xhr.statusText);
+      handleStorageError: function(e, resp) {
+        console.log("Storage Error: " + resp.xhr.status + " " + resp.xhr.statusText);
 
         this.fire("rise-storage-error", resp);
+      },
+
+      handlePingResponse: function(e, resp) {
+        if (resp.response === "") {
+          this.isCacheRunning = false;
+        }
+        else {
+          this.isCacheRunning = true;
+        }
+
+        this.go();
+      },
+
+      handlePingError: function(e, resp) {
+        console.log("Ping Error: " + resp.xhr.status + " " + resp.xhr.statusText);
+
+        this.isCacheRunning = false;
+        this.go();
       },
 
       /**
@@ -208,7 +252,7 @@ You can trigger a request explicitly by calling `go` on the element.
        * @method go
        */
       go: function() {
-        this.$.ajax.go();
+        this.$.storage.go();
       }
     });
   </script>

--- a/test/rise-storage-test.html
+++ b/test/rise-storage-test.html
@@ -17,7 +17,6 @@
   <script src="/components/webcomponentsjs/webcomponents.js"></script>
   <script src="/components/web-component-tester/browser.js"></script>
 
-  <!-- Step 1: import the element to test -->
   <link rel="import" href="/rise-storage/rise-storage.html">
 </head>
 <body>
@@ -61,7 +60,7 @@
           assert.equal(storage.folderRefresh, 0);
         });
 
-        test("urls have the expected values", function() {
+        test("Storage URLs have the expected values", function() {
           assert.equal(storage.url, "");
           assert.equal(storage2.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o");
           assert.equal(storage3.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o?delimiter=/&prefix=my-folder/");
@@ -70,10 +69,14 @@
         });
       });
 
-      suite("requests", function() {
+      suite("Storage requests", function() {
         var headers = {
             "Content-Type": "text/json"
           },
+          bucketFile = JSON.stringify({
+            "contentType": "image/jpeg",
+            "mediaLink": "https://url.to.my-image.jpg"
+          }),
           multipleFiles = JSON.stringify({
             "items": [{
               "contentType": "image/jpeg",
@@ -119,17 +122,12 @@
         });
 
         test("should get a specific file in a bucket", function(done) {
-          var singleFile = JSON.stringify({
-            "contentType": "image/jpeg",
-            "mediaLink": "https://url.to.my-image.jpg"
-          });
-
           storage4.addEventListener("rise-storage-response", function(response) {
             assert.equal(response.detail.length, 1);
           });
 
           storage4.go();
-          requests[0].respond(200, headers, singleFile);
+          requests[0].respond(200, headers, bucketFile);
           done();
         });
 
@@ -147,6 +145,31 @@
 
           storage5.go();
           requests[0].respond(200, headers, singleFile);
+          done();
+        });
+
+        test("should return Rise Cache URLs for multiple files in a folder", function(done) {
+          storage3.addEventListener("rise-storage-response", function(response) {
+            assert.equal(response.detail.length, 2);
+            assert.equal(response.detail[0], "http://localhost:9494/?url=https%3A//url.to.my-image.jpg");
+            assert.equal(response.detail[1], "http://localhost:9494/?url=https%3A//url.to.my-image.gif");
+          });
+
+          storage3.isCacheRunning = true;
+          storage3.go();
+          requests[0].respond(200, headers, multipleFiles);
+          done();
+        });
+
+        test("should return Rise Cache URLs for a specific file in a bucket", function(done) {
+          storage4.addEventListener("rise-storage-response", function(response) {
+            assert.equal(response.detail.length, 1);
+            assert.equal(response.detail[0], "http://localhost:9494/?url=https%3A//url.to.my-image.jpg");
+          });
+
+          storage4.isCacheRunning = true;
+          storage4.go();
+          requests[0].respond(200, headers, bucketFile);
           done();
         });
 
@@ -211,6 +234,42 @@
         });
       });
 
+      suite("Ping request", function() {
+        var headers = {
+          "Content-Type": "text/plain"
+        };
+
+        test("should make a ping request with Rise Cache running", function(done) {
+          storage2.$.ping.go();
+          requests[0].respond(200, headers, "handlePingResponse();");
+
+          // Ping request + storage request
+          assert.equal(requests.length, 2);
+          assert.isTrue(storage2.isCacheRunning);
+          done();
+        });
+
+        test("should make a ping request with Rise Cache not running", function(done) {
+          storage2.$.ping.go();
+          requests[0].respond(200, headers, "");
+
+          // Ping request + storage request
+          assert.equal(requests.length, 2);
+          assert.isFalse(storage2.isCacheRunning);
+          done();
+        });
+
+        test("should error out on a ping request", function(done) {
+          storage2.$.ping.go();
+          requests[0].respond(404, headers, "handlePingResponse();");
+
+          // Ping request + storage request
+          assert.equal(requests.length, 2);
+          assert.isFalse(storage2.isCacheRunning);
+          done();
+        });
+      });
+
       suite("refresh", function() {
         var clock;
 
@@ -223,22 +282,26 @@
         });
 
         test("should check for changes to a folder", function() {
-          var spy = sinon.spy(storage3, "go");
+          var pingSpy = sinon.spy(storage3.$.ping, "go"),
+            timerSpy = sinon.spy(storage3, "startTimer");
 
           storage3.startTimer();
           clock.tick(9999);
-          assert(spy.notCalled);
+          assert(pingSpy.notCalled);
 
           clock.tick(1);
-          assert(spy.calledOnce);
+          assert(pingSpy.calledOnce);
+          assert(timerSpy.calledTwice);
         });
 
         test("should not check for changes to a file", function() {
-          var spy = sinon.spy(storage4, "go");
+          var pingSpy = sinon.spy(storage4.$.ping, "go"),
+            timerSpy = sinon.spy(storage4, "startTimer");
 
-          storage4.startTimer(spy);
+          storage4.startTimer(pingSpy);
           clock.tick(10000);
-          assert(spy.notCalled);
+          assert(pingSpy.notCalled);
+          assert(timerSpy.calledOnce);
         });
       });
 


### PR DESCRIPTION
The program flow is that Rise Cache will first be pinged to see if it’s running. Then a request is made to Rise Storage to get the list of the files. If Rise Cache is running, the URLs will be altered so that they point to Rise Cache; otherwise, the URLs are passed as is from Storage.
