### PR TITLE
Fix getting all files in a bucket

### DIFF
--- a/rise-storage/rise-storage.html
+++ b/rise-storage/rise-storage.html
@@ -93,24 +93,30 @@
       },
 
       setUrl: function() {
-        var url = "";
+        var baseUrl = "https://www.googleapis.com/storage/v1/b/risemedialibrary-" + encodeURIComponent(this.companyId) + "/o",
+          delimiter = "?delimiter=" + encodeURIComponent("/"),
+          folder = "&prefix=" + encodeURIComponent(this.folder) + "/",
+          fileName = encodeURIComponent(this.fileName),
+          url = baseUrl;
 
         if (this.companyId) {
-          url = "https://www.googleapis.com/storage/v1/b/risemedialibrary-" + encodeURIComponent(this.companyId) + "/o";
-
           if (this.folder) {
             // Get a specific file in a specific folder.
             if (this.fileName) {
-              url += "?delimiter=/&prefix=" + encodeURIComponent(this.folder) + "/" + encodeURIComponent(this.fileName);
+              url += delimiter + folder + fileName;
             }
             // Get all files in a specific folder.
             else {
-              url += "?delimiter=/&prefix=" + encodeURIComponent(this.folder) + "/";
+              url += delimiter + folder;
             }
           }
           // Get a specific file in a bucket.
           else if (this.fileName) {
-            url += "/" + encodeURIComponent(this.fileName);
+            url += "/" + fileName;
+          }
+          // Get all files in a bucket.
+          else {
+            url += delimiter;
           }
 
           this.url = url;
@@ -155,7 +161,7 @@
         if (resp && resp.response && resp.response.items) {
           resp.response.items.forEach(function(elem) {
             // Check that this is not the folder itself.
-            if (elem.contentType && elem.contentType !== "text/plain") {
+            if (elem.name && (elem.name.slice(-1) !== "/")) {
               if (elem.mediaLink) {
                 if (self.isCacheRunning) {
                   urls.push("http://localhost:9494/?url=" + escape(elem.mediaLink));

--- a/test/rise-storage-test.html
+++ b/test/rise-storage-test.html
@@ -62,10 +62,10 @@
 
         test("Storage URLs have the expected values", function() {
           assert.equal(storage.url, "");
-          assert.equal(storage2.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o");
-          assert.equal(storage3.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o?delimiter=/&prefix=my-folder/");
+          assert.equal(storage2.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o?delimiter=%2F");
+          assert.equal(storage3.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o?delimiter=%2F&prefix=my-folder/");
           assert.equal(storage4.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/my-image.png");
-          assert.equal(storage5.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o?delimiter=/&prefix=my-folder/my-image.png");
+          assert.equal(storage5.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o?delimiter=%2F&prefix=my-folder/my-image.png");
         });
       });
 
@@ -74,21 +74,25 @@
             "Content-Type": "text/json"
           },
           bucketFile = JSON.stringify({
+            "name": "my-image.jpg",
             "contentType": "image/jpeg",
             "mediaLink": "https://url.to.my-image.jpg"
           }),
           multipleFiles = JSON.stringify({
             "items": [{
+              "name": "my-folder/",
+              "contentType": "text/plain",
+              "mediaLink": "https://url.to.my-folder"
+            },
+            {
+              "name": "my-folder/my-image.jpg",
               "contentType": "image/jpeg",
               "mediaLink": "https://url.to.my-image.jpg"
             },
             {
+              "name": "my-folder/my-image.gif",
               "contentType": "image/gif",
               "mediaLink": "https://url.to.my-image.gif"
-            },
-            {
-              "contentType": "text/plain",
-              "mediaLink": "https://url.to.my-folder"
             }]
           });
 
@@ -102,12 +106,25 @@
         });
 
         test("should get files in a bucket", function(done) {
+          var multipleBucketFiles = JSON.stringify({
+            "items": [{
+              "name": "my-image.jpg",
+              "contentType": "image/jpeg",
+              "mediaLink": "https://url.to.my-image.jpg"
+            },
+            {
+              "name": "my-image.gif",
+              "contentType": "image/gif",
+              "mediaLink": "https://url.to.my-image.gif"
+            }]
+          });
+
           storage2.addEventListener("rise-storage-response", function(response) {
             assert.equal(response.detail.length, 2);
           });
 
           storage2.go();
-          requests[0].respond(200, headers, multipleFiles);
+          requests[0].respond(200, headers, multipleBucketFiles);
           done();
         });
 
@@ -134,6 +151,7 @@
         test("should get a specific file in a folder", function(done) {
           var singleFile = JSON.stringify({
             "items": [{
+              "name": "my-folder/my-image.jpg",
               "contentType": "image/jpeg",
               "mediaLink": "https://url.to.my-image.jpg"
             }]


### PR DESCRIPTION
- Change API call for getting all files in a bucket to include a delimiter so that only files in the root bucket are returned, instead of all files in both the root and inside of folders.
- Switch to a different method of checking whether a particular entry is a folder by checking if the last character in the name property is a `/`.
- Encode the delimiter parameter.
