### PR TITLE
`storage.go()` must be called manually (closes #21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ You can access the `demo.html` file via a local web server. On Mac, execute the 
 python -m SimpleHTTPServer
 ```
 
-This starts a web server on port 8000, and you can access the Rise Storage web component by navigating to `localhost:8000/rise-storage/demo.html`.
+This starts a web server on port 8000, and you can access the Rise Storage web component by navigating to `localhost:8000/demo.html`.
 
 ### Testing
 You can run the suite of tests via a local web server. On Mac, execute the following command from the root directory of the web component:

--- a/demo.html
+++ b/demo.html
@@ -20,6 +20,10 @@
     storage.addEventListener("rise-storage-response", function(e) {
       image.setAttribute("src", e.detail[0]);
     });
+
+    window.addEventListener("polymer-ready", function() {
+      storage.go();
+    });
   </script>
 
 </body>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,13 +13,13 @@
       .pipe(bump({type:"patch"}))
       .pipe(gulp.dest("./"));
 
-    gulp.src(["./rise-storage/bower.json"])
+    gulp.src(["./bower.json"])
       .pipe(bump({type:"patch"}))
-      .pipe(gulp.dest("./rise-storage/"));
+      .pipe(gulp.dest("./"));
   });
 
   gulp.task("lint", function() {
-    return gulp.src("./rise-storage/*.html")
+    return gulp.src("./*.html")
       .pipe(jshint.extract("always"))
       .pipe(jshint())
       .pipe(jshint.reporter("jshint-stylish"))
@@ -27,7 +27,7 @@
   });
 
   gulp.task("watch",function(){
-    gulp.watch("./rise-storage/*.html", ["build"]);
+    gulp.watch("./*.html", ["build"]);
   });
 
   gulp.task("build", function (cb) {

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -121,8 +121,6 @@
 
           this.url = url;
         }
-
-        this.$.ping.go();
       },
 
       startTimer: function() {

--- a/test/rise-storage-test.html
+++ b/test/rise-storage-test.html
@@ -17,7 +17,7 @@
   <script src="/components/webcomponentsjs/webcomponents.js"></script>
   <script src="/components/web-component-tester/browser.js"></script>
 
-  <link rel="import" href="/rise-storage/rise-storage.html">
+  <link rel="import" href="/rise-storage.html">
 </head>
 <body>
 
@@ -327,7 +327,7 @@
       });
 
       suite("triggers", function() {
-        test("should trigger request when companyId changed", function(done) {
+        test("should not trigger request when companyId changed", function(done) {
           async.series([
             function(cb) {
               storage.companyId = "my-companyId";
@@ -340,13 +340,13 @@
               });
             },
             function(cb) {
-              assert.equal(requests.length, 1);
+              assert.equal(requests.length, 0);
               cb();
             }
             ], done);
         });
 
-        test("should trigger request when folder changed", function(done) {
+        test("should not trigger request when folder changed", function(done) {
           async.series([
             function(cb) {
               storage.folder = "new-folder";
@@ -359,16 +359,35 @@
               });
             },
             function(cb) {
-              assert.equal(requests.length, 1);
+              assert.equal(requests.length, 0);
               cb();
             }
             ], done);
         });
 
-        test("should trigger request when fileName changed", function(done) {
+        test("should not trigger request when fileName changed", function(done) {
           async.series([
             function(cb) {
               storage.fileName = "new-fileName";
+              cb();
+            },
+            flush,
+            function(cb) {
+              requestAnimationFrame(function() {
+                cb();
+              });
+            },
+            function(cb) {
+              assert.equal(requests.length, 0);
+              cb();
+            }
+            ], done);
+        });
+
+        test("should trigger request when called manually", function(done) {
+          async.series([
+            function(cb) {
+              storage.go();
               cb();
             },
             flush,


### PR DESCRIPTION
- fix links to the web component
- remove automatic call to `go()` when attributes change
- update tests
- update demo page
