### PR TITLE
Fix Storage folder URL

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "authors": [
     "Donna Peplinskie <donna.peplinskie@risevision.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-component-rise-storage",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "The Rise Storage Web Component uses Google’s storage API to retrieve the URLs of all files in a particular folder, or the URL of a single file in a particular folder, from Rise Storage.",
   "directories": {
     "test": "test"

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -20,7 +20,7 @@
   </template>
 
   <script>
-    /* global Polymer */
+    /* global Polymer, _ */
     /*jshint newcap: false */
     Polymer("rise-storage", {
       /**
@@ -145,12 +145,17 @@
       setUrl: function() {
         var baseUrl = "https://www.googleapis.com/storage/v1/b/risemedialibrary-" + encodeURIComponent(this.companyId) + "/o",
           delimiter = "?delimiter=" + encodeURIComponent("/"),
-          folder = "&prefix=" + encodeURIComponent(this.folder) + "/",
+          folder = "&prefix=" + encodeURIComponent(this.folder),
           fileName = encodeURIComponent(this.fileName),
           url = baseUrl;
 
         if (this.companyId) {
           if (this.folder) {
+            // Append a "/" at end of folder if necessary.
+            if (this.folder.slice(-1) !== "/") {
+              folder += "/";
+            }
+
             // Get a specific file in a specific folder.
             if (this.fileName) {
               url += delimiter + folder + fileName;


### PR DESCRIPTION
URLs coming from the Storage selector will already have a / appended to
the folder name, so don’t add another one.