### PR TITLE
Chore/cache buster rise cache

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "authors": [
     "Donna Peplinskie <donna.peplinskie@risevision.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-component-rise-storage",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "The Rise Storage Web Component uses Google’s storage API to retrieve the URLs of all files in a particular folder, or the URL of a single file in a particular folder, from Rise Storage.",
   "scripts": {
     "test": "gulp test",

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -121,6 +121,15 @@
       sortDirection: "",
 
       /**
+       * Indicates whether or not the component is loading.
+       *
+       * @property isLoading
+       * @type boolean
+       * @default true
+       */
+      isLoading: true,
+
+      /**
        * The URL target of the request.
        *
        * @property url
@@ -128,6 +137,15 @@
        * @default ""
        */
       url: "",
+
+      /**
+       * Stores item details from the previous request.
+       *
+       * @property items
+       * @type object
+       * @default []
+       */
+      items: [],
 
       /**
        * The base URL for Rise Cache.
@@ -474,7 +492,8 @@
           file = {},
           files = [],
           response = null,
-          suffix = "?alt=media";
+          previousItem = null,
+          suffix = "?alt=media&cb=" + new Date().getTime();
 
         if (resp && resp.response && resp.response.items) {
           resp.response.items.forEach(function(item) {
@@ -497,22 +516,93 @@
                   }
                 }
 
-                file.url = self.isCacheRunning ? (self.riseCacheUrl + escape(item.selfLink) + suffix) : (item.selfLink + suffix);
+                // Construct URL.
+                file.url = self.isCacheRunning ? (self.riseCacheUrl + escape(item.selfLink) + suffix) :
+                  (item.selfLink + suffix);
+
+                // Initial load
+                if (self.isLoading) {
+                  self.items.push({
+                    "name": item.name,
+                    "etag": item.etag,
+                    "url": file.url
+                  });
+                }
+                else {
+                  previousItem = _.find(self.items, function(obj) {
+                    return obj.name === item.name;
+                  });
+
+                  // New file
+                  if (previousItem === undefined) {
+                    self.items.push({
+                      "name": item.name,
+                      "etag": item.etag,
+                      "url": file.url
+                    });
+                  }
+                  // Existing file
+                  else {
+                    if (item.etag) {
+                      // File hasn't changed; use the same URL as before in order to leverage caching.
+                      if (item.etag === previousItem.etag) {
+                        file.url = previousItem.url;
+                      }
+                      // File has changed.
+                      else {
+                        previousItem.url = file.url;
+                        previousItem.etag = item.etag;
+                      }
+                    }
+                    // No etag
+                    else {
+                      previousItem.url = file.url;
+                      previousItem.etag = "";
+                    }
+                  }
+                }
 
                 files.push(file);
               }
             }
           });
+
+          self.isLoading = false;
         }
         // A single file stored in the root of a bucket has a different response format.
         else if (resp && resp.response && resp.response.selfLink) {
-          file.url = self.isCacheRunning ? (self.riseCacheUrl + escape(resp.response.selfLink) + suffix) : (resp.response.selfLink + suffix);
+          file.url = self.isCacheRunning ? (self.riseCacheUrl + escape(resp.response.selfLink) + suffix) :
+            (resp.response.selfLink + suffix);
+
+          // Initial load
+          if (self.isLoading) {
+            self.items.push({
+              "name": resp.response.name,
+              "etag": resp.response.etag,
+              "url": file.url
+            });
+
+            self.isLoading = false;
+          }
+          else {
+            if (resp.response.etag) {
+              // File hasn't changed.
+              if (resp.response.etag === self.items[0].etag) {
+                this.startTimer();
+                return;
+              }
+              // File has changed.
+              else {
+                self.items[0].url = file.url;
+                self.items[0].etag = resp.response.etag;
+              }
+            }
+          }
 
           files.push(file);
         }
 
         response = this.prepareResponse(files);
-
         this.startTimer();
         this.fire("rise-storage-response", response);
       },

--- a/test/index.html
+++ b/test/index.html
@@ -12,6 +12,8 @@
     <script>
       WCT.loadSuites([
         "rise-storage.html",
+        "rise-storage-bucket.html",
+        "rise-storage-folder.html",
         "rise-storage-cache.html",
         "rise-storage-filter.html",
         "rise-storage-sort.html",

--- a/test/js/rise-storage-data.js
+++ b/test/js/rise-storage-data.js
@@ -1,66 +1,76 @@
 var header = { "Content-Type": "text/json" },
   folderFiles = JSON.stringify({
     "items": [{
-      "name": "my-folder/",
+      "name": "images/",
       "contentType": "text/plain",
       "updated": "2015-02-04T17:44:00.549Z",
-      "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2F"
+      "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2F",
+      "etag": "CIjxrtzryMMCEAE="
     },
     {
-      "name": "my-folder/home.jpg",
+      "name": "images/home.jpg",
       "contentType": "image/jpeg",
       "updated": "2015-02-04T17:45:25.945Z",
-      "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg"
+      "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg",
+      "etag": "COjLvarr/cQCEAE="
     },
     {
-      "name": "my-folder/circle.png",
+      "name": "images/circle.png",
       "contentType": "image/png",
       "updated": "2015-02-06T14:25:11.312Z",
-      "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png"
+      "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png",
+      "etag": "CMiEudSn2MMCEAs="
     },
     {
-      "name": "my-folder/my-image.bmp",
+      "name": "images/my-image.bmp",
       "contentType": "image/bmp",
       "updated": "2015-02-06T11:24:13.313Z",
-      "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp"
+      "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp",
+      "etag": "CJi3zten2MMCEA0="
     },
     {
-      "name": "my-folder/golf.svg",
+      "name": "images/golf.svg",
       "contentType": "image/svg+xml",
       "updated": "2015-01-30T08:19:09.263Z",
-      "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg"
+      "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg",
+      "etag": "CPjC1qHc7MQCEAE="
     },
     {
-      "name": "my-folder/turtle.gif",
+      "name": "images/turtle.gif",
       "contentType": "image/gif",
       "updated": "2015-02-04T17:46:31.263Z",
-      "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fturtle.gif"
+      "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fturtle.gif",
+      "etag": "CLCKypbW/cQCEAE="
     },
     {
-      "name": "my-folder/car-ad.mp4",
+      "name": "images/car-ad.mp4",
       "contentType": "video/mp4",
       "updated": "2015-02-02T10:03:11.263Z",
-      "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcar-ad.mp4"
+      "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcar-ad.mp4",
+      "etag": "CKCa+Y2nq8MCEAM="
     },
     {
-      "name": "my-folder/walking-dead.ogv",
+      "name": "images/walking-dead.ogv",
       "contentType": "video/ogg",
       "updated": "2015-02-01T09:08:15.263Z",
-      "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fwalking-dead.ogv"
+      "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fwalking-dead.ogv",
+      "etag": "CJC2jJrFqsMCEAE="
     },
     {
-      "name": "my-folder/south-park.webm",
+      "name": "images/south-park.webm",
       "contentType": "video/webm",
       "updated": "2015-02-03T19:13:45.263Z",
-      "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fsouth-park.webm"
+      "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fsouth-park.webm",
+      "etag": "CLDO+JDspcMCEAE="
     }]
   }),
   folderFile = JSON.stringify({
     "items": [{
-      "name": "my-folder/home.jpg",
+      "name": "images/home.jpg",
       "contentType": "image/jpeg",
       "updated": "2015-02-04T17:45:25.945Z",
-      "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg"
+      "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg",
+      "etag": "COjLvarr/cQCEAE="
     }]
   }),
   bucketFiles = JSON.stringify({
@@ -68,20 +78,23 @@ var header = { "Content-Type": "text/json" },
       "name": "home.jpg",
       "contentType": "image/jpeg",
       "updated": "2015-02-04T17:45:25.945Z",
-      "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg"
+      "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg",
+      "etag": "COjLvarr/cQCEAE="
     },
     {
       "name": "turtle.gif",
       "contentType": "image/gif",
       "updated": "2015-02-04T17:46:31.263Z",
-      "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fturtle.gif"
+      "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fturtle.gif",
+      "etag": "CLCKypbW/cQCEAE="
     }]
   }),
   bucketFile = JSON.stringify({
     "name": "home.jpg",
     "contentType": "image/jpeg",
     "updated": "2015-02-04T17:45:25.945Z",
-    "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg"
+    "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg",
+    "etag": "COjLvarr/cQCEAE="
   }),
   invalidCompanyData = JSON.stringify({
     "error": {

--- a/test/rise-storage-bucket.html
+++ b/test/rise-storage-bucket.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>rise-storage</title>
+
+  <script src="../../webcomponentsjs/webcomponents.min.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+
+  <link rel="import" href="../rise-storage.html">
+</head>
+<body>
+  <rise-storage id="bucket" companyId="abc123"></rise-storage>
+  <rise-storage id="file" companyId="abc123" fileName="home.jpg"></rise-storage>
+
+  <script src="js/rise-storage-data.js"></script>
+  <script>
+    suite("rise-storage", function() {
+      var responded,
+        bucket = document.querySelector("#bucket"),
+        file = document.querySelector("#file");
+
+      suiteSetup(function() {
+        xhr = sinon.useFakeXMLHttpRequest();
+
+        xhr.onCreate = function (xhr) {
+          requests.push(xhr);
+        };
+      });
+
+      suiteTeardown(function() {
+        xhr.restore();
+      });
+
+      setup(function() {
+        requests = [];
+        responded = false;
+      });
+
+      suite("bucket", function() {
+        test("should get all files in a bucket", function(done) {
+          var listener = function(response) {
+            assert.equal(response.detail.files.length, 2);
+            bucket.removeEventListener("rise-storage-response", listener);
+          };
+
+          bucket.addEventListener("rise-storage-response", listener);
+          bucket.pingReceived = true;
+          bucket.go();
+          requests[0].respond(200, header, bucketFiles);
+          done();
+        });
+
+        test("should get a specific file in a bucket", function(done) {
+          var listener = function(response) {
+            assert.equal(response.detail.files.length, 1);
+            file.removeEventListener("rise-storage-response", listener);
+          };
+
+          file.addEventListener("rise-storage-response", listener);
+          file.go();
+          requests[0].respond(200, header, bucketFile);
+          done();
+        });
+
+        test("should not fire rise-storage-response if the bucket file has not changed", function(done) {
+          var listener = function(response) {
+            responded = true;
+            file.removeEventListener("rise-storage-response", listener);
+          };
+
+          file.addEventListener("rise-storage-response", listener);
+          file.go();
+          requests[0].respond(200, header, bucketFile);
+          assert.isFalse(responded);
+          done();
+        });
+
+        test("should fire rise-storage-response if the bucket file has changed", function(done) {
+          var listener = function(response) {
+            responded = true;
+            file.removeEventListener("rise-storage-response", listener);
+          };
+
+          file.addEventListener("rise-storage-response", listener);
+          file.go();
+          requests[0].respond(200, header, JSON.stringify({
+            "name": "home.jpg",
+            "contentType": "image/jpeg",
+            "updated": "2015-02-04T17:45:25.945Z",
+            "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg",
+            "etag": "CMiEudSn2MMCEAs="
+          }));
+          assert.isTrue(responded);
+          done();
+        });
+      });
+    });
+  </script>
+</body>
+</html>

--- a/test/rise-storage-cache.html
+++ b/test/rise-storage-cache.html
@@ -70,12 +70,12 @@
       });
 
       test("should return Rise Cache URLs for multiple files in a folder", function(done) {
-        listener = function(response) {
+        var listener = function(response) {
           assert.equal(response.detail.files.length, 8);
-          assert.equal(JSON.stringify(response.detail.files[0]),
-            '{"url":"http://localhost:9494/?url=https%3A//www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%252Fhome.jpg?alt=media"}');
-          assert.equal(JSON.stringify(response.detail.files[1]),
-            '{"url":"http://localhost:9494/?url=https%3A//www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%252Fcircle.png?alt=media"}');
+          assert.include(JSON.stringify(response.detail.files[0]),
+            '{"url":"http://localhost:9494/?url=https%3A//www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%252Fhome.jpg?alt=media&cb=');
+          assert.include(JSON.stringify(response.detail.files[1]),
+            '{"url":"http://localhost:9494/?url=https%3A//www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%252Fcircle.png?alt=media&cb=');
           folder.removeEventListener("rise-storage-response", listener);
         };
 
@@ -88,10 +88,10 @@
       });
 
       test("should return Rise Cache URLs for a specific file in a bucket", function(done) {
-        listener = function(response) {
+        var listener = function(response) {
           assert.equal(response.detail.files.length, 1);
-          assert.equal(JSON.stringify(response.detail.files[0]),
-            '{"url":"http://localhost:9494/?url=https%3A//www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%252Fhome.jpg?alt=media"}');
+          assert.include(JSON.stringify(response.detail.files[0]),
+            '{"url":"http://localhost:9494/?url=https%3A//www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media&cb=');
           file.removeEventListener("rise-storage-response", listener);
         };
 

--- a/test/rise-storage-filter.html
+++ b/test/rise-storage-filter.html
@@ -37,7 +37,7 @@
       });
 
       test("should return only image files when filtering by fileType", function(done) {
-        listener = function(response) {
+        var listener = function(response) {
           assert.equal(response.detail.files.length, 5);
           fileType.removeEventListener("rise-storage-response", listener);
         };
@@ -49,7 +49,7 @@
       });
 
       test("should return only video files when filtering by fileType", function(done) {
-        listener = function(response) {
+        var listener = function(response) {
           assert.equal(response.detail.files.length, 3);
           fileType.removeEventListener("rise-storage-response", listener);
         };
@@ -62,12 +62,12 @@
       });
 
       test("should return only .jpg and .png files when filtering by contentType", function(done) {
-        listener = function(response) {
+        var listener = function(response) {
           assert.equal(response.detail.files.length, 2);
-          assert.equal(JSON.stringify(response.detail.files[0]),
-            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media"}');
-          assert.equal(JSON.stringify(response.detail.files[1]),
-            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media"}');
+          assert.include(JSON.stringify(response.detail.files[0]),
+            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&cb=');
+          assert.include(JSON.stringify(response.detail.files[1]),
+            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&cb=');
           contentType.removeEventListener("rise-storage-response", listener);
         };
 

--- a/test/rise-storage-folder.html
+++ b/test/rise-storage-folder.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>rise-storage</title>
+
+  <script src="../../webcomponentsjs/webcomponents.min.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+
+  <link rel="import" href="../rise-storage.html">
+</head>
+<body>
+  <rise-storage id="folder" companyId="abc123" folder="images"></rise-storage>
+  <rise-storage id="file-folder" companyId="abc123" folder="images" fileName="home.jpg"></rise-storage>
+
+  <script src="js/rise-storage-data.js"></script>
+  <script>
+    suite("rise-storage", function() {
+      var responded,
+        url = "",
+        folder = document.querySelector("#folder"),
+        fileFolder = document.querySelector("#file-folder");
+
+      suiteSetup(function() {
+        xhr = sinon.useFakeXMLHttpRequest();
+
+        xhr.onCreate = function (xhr) {
+          requests.push(xhr);
+        };
+      });
+
+      suiteTeardown(function() {
+        xhr.restore();
+      });
+
+      setup(function() {
+        requests = [];
+        responded = false;
+      });
+
+      suite("folder", function() {
+        test("should get a specific file in a folder", function(done) {
+          var listener = function(response) {
+            url = response.detail.files[0].url;
+
+            assert.equal(response.detail.files.length, 1);
+            assert.include(response.detail.files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&cb=");
+            fileFolder.removeEventListener("rise-storage-response", listener);
+          };
+
+          fileFolder.addEventListener("rise-storage-response", listener);
+          fileFolder.go();
+          requests[0].respond(200, header, folderFile);
+          done();
+        });
+
+        test("should return the same URL if the file has not changed", function(done) {
+          var listener = function(response) {
+            assert.equal(response.detail.files[0].url, url);
+            fileFolder.removeEventListener("rise-storage-response", listener);
+          };
+
+          fileFolder.addEventListener("rise-storage-response", listener);
+          fileFolder.go();
+          requests[0].respond(200, header, folderFile);
+          done();
+        });
+
+        test("should return a different URL if the file has changed", function(done) {
+          var listener = function(response) {
+            assert.notEqual(response.detail.files[0].url, url);
+            assert.include(response.detail.files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&cb=");
+            fileFolder.removeEventListener("rise-storage-response", listener);
+          };
+
+          fileFolder.addEventListener("rise-storage-response", listener);
+          fileFolder.go();
+          requests[0].respond(200, header, JSON.stringify({
+            "items": [{
+              "name": "images/home.jpg",
+              "contentType": "image/jpeg",
+              "updated": "2015-02-04T17:45:25.945Z",
+              "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg",
+              "etag": "CLDO+JDspcMCEAE="
+            }]
+          }));
+          done();
+        });
+
+        test("should return added file", function(done) {
+          var listener = function(response) {
+            assert.equal(response.detail.files.length, 2);
+            assert.include(response.detail.files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&cb=");
+            fileFolder.removeEventListener("rise-storage-response", listener);
+          };
+
+          fileFolder.addEventListener("rise-storage-response", listener);
+          fileFolder.go();
+          requests[0].respond(200, header, JSON.stringify({
+            "items": [{
+              "name": "images/home.jpg",
+              "contentType": "image/jpeg",
+              "updated": "2015-02-04T17:45:25.945Z",
+              "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg",
+              "etag": "CLDO+JDspcMCEAE="
+            },
+            {
+              "name": "images/circle.png",
+              "contentType": "image/png",
+              "updated": "2015-02-06T14:25:11.312Z",
+              "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png",
+              "etag": "CMiEudSn2MMCEAs="
+            }]
+          }));
+          done();
+        });
+
+        test("should not return deleted file", function(done) {
+          var listener = function(response) {
+            assert.equal(response.detail.files.length, 1);
+            fileFolder.removeEventListener("rise-storage-response", listener);
+          };
+
+          fileFolder.addEventListener("rise-storage-response", listener);
+          fileFolder.go();
+          requests[0].respond(200, header, JSON.stringify({
+            "items": [{
+              "name": "images/home.jpg",
+              "contentType": "image/jpeg",
+              "updated": "2015-02-04T17:45:25.945Z",
+              "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg",
+              "etag": "CLDO+JDspcMCEAE="
+            }]
+          }));
+          done();
+        });
+
+        test("should still return a file when the etag is missing", function(done) {
+          var listener = function(response) {
+            assert.equal(response.detail.files.length, 1);
+            fileFolder.removeEventListener("rise-storage-response", listener);
+          };
+
+          fileFolder.addEventListener("rise-storage-response", listener);
+          fileFolder.go();
+          requests[0].respond(200, header, JSON.stringify({
+            "items": [{
+              "name": "images/home.jpg",
+              "contentType": "image/jpeg",
+              "updated": "2015-02-04T17:45:25.945Z",
+              "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg"
+            }]
+          }));
+          done();
+        });
+
+        test("should get files in a folder", function(done) {
+          var listener = function(response) {
+            assert.equal(response.detail.files.length, 8);
+            folder.removeEventListener("rise-storage-response", listener);
+          };
+
+          folder.addEventListener("rise-storage-response", listener);
+          folder.go();
+          requests[0].respond(200, header, folderFiles);
+          done();
+        });
+      });
+    });
+  </script>
+</body>
+</html>

--- a/test/rise-storage-invalid.html
+++ b/test/rise-storage-invalid.html
@@ -57,7 +57,7 @@
         });
 
       test("should fire rise-storage-error for an invalid companyId", function(done) {
-        var responded;
+        var responded, listener;
 
         listener = function(response) {
           responded = true;
@@ -72,7 +72,7 @@
       });
 
       test("should return an empty object for an invalid folder or file", function(done) {
-        listener = function(response) {
+        var listener = function(response) {
           assert.equal(JSON.stringify(response.detail), '{"files":[]}');
 
           invalidFolder.removeEventListener("rise-storage-response", listener);
@@ -85,7 +85,7 @@
       });
 
       test("should not return any files for an invalid file type", function(done) {
-        listener = function(response) {
+        var listener = function(response) {
           assert.equal(response.detail.files.length, 0);
 
           invalidFileType.removeEventListener("rise-storage-response", listener);
@@ -98,7 +98,7 @@
       });
 
       test("should not return any files for an invalid content type", function(done) {
-        listener = function(response) {
+        var listener = function(response) {
           assert.equal(response.detail.files.length, 0);
 
           invalidContentType.removeEventListener("rise-storage-response", listener);
@@ -111,13 +111,13 @@
       });
 
       test("should not sort files for an invalid sort", function(done) {
-        listener = function(response) {
-          assert.equal(JSON.stringify(response.detail.files[0]),
-            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcar-ad.mp4?alt=media"}');
-          assert.equal(JSON.stringify(response.detail.files[1]),
-            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fwalking-dead.ogv?alt=media"}');
-          assert.equal(JSON.stringify(response.detail.files[2]),
-            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fsouth-park.webm?alt=media"}');
+        var listener = function(response) {
+          assert.include(JSON.stringify(response.detail.files[0]),
+            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcar-ad.mp4?alt=media&cb=');
+          assert.include(JSON.stringify(response.detail.files[1]),
+            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fwalking-dead.ogv?alt=media&cb=');
+          assert.include(JSON.stringify(response.detail.files[2]),
+            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fsouth-park.webm?alt=media&cb=');
 
           invalidSort.removeEventListener("rise-storage-response", listener);
         };
@@ -129,13 +129,13 @@
       });
 
       test("should sort files in ascending order for an invalid sort direction", function(done) {
-        listener = function(response) {
-          assert.equal(JSON.stringify(response.detail.files[0]),
-            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcar-ad.mp4?alt=media"}');
-          assert.equal(JSON.stringify(response.detail.files[1]),
-            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fsouth-park.webm?alt=media"}');
-          assert.equal(JSON.stringify(response.detail.files[2]),
-            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fwalking-dead.ogv?alt=media"}');
+        var listener = function(response) {
+          assert.include(JSON.stringify(response.detail.files[0]),
+            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcar-ad.mp4?alt=media&cb=');
+          assert.include(JSON.stringify(response.detail.files[1]),
+            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fsouth-park.webm?alt=media&cb=');
+          assert.include(JSON.stringify(response.detail.files[2]),
+            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fwalking-dead.ogv?alt=media&cb=');
 
           invalidSortDirection.removeEventListener("rise-storage-response", listener);
         };

--- a/test/rise-storage-sort.html
+++ b/test/rise-storage-sort.html
@@ -35,13 +35,13 @@
       });
 
       test("should sort in ascending order by name", function(done) {
-        listener = function(response) {
-          assert.equal(JSON.stringify(response.detail.files[0]),
-            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcar-ad.mp4?alt=media"}');
-          assert.equal(JSON.stringify(response.detail.files[1]),
-            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fsouth-park.webm?alt=media"}');
-          assert.equal(JSON.stringify(response.detail.files[2]),
-            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fwalking-dead.ogv?alt=media"}');
+        var listener = function(response) {
+          assert.include(JSON.stringify(response.detail.files[0]),
+            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcar-ad.mp4?alt=media&cb=');
+          assert.include(JSON.stringify(response.detail.files[1]),
+            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fsouth-park.webm?alt=media&cb=');
+          assert.include(JSON.stringify(response.detail.files[2]),
+            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fwalking-dead.ogv?alt=media&cb=');
           sorting.removeEventListener("rise-storage-response", listener);
         };
 
@@ -52,13 +52,13 @@
       });
 
       test("should sort in descending order by name", function(done) {
-        listener = function(response) {
-          assert.equal(JSON.stringify(response.detail.files[0]),
-            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fwalking-dead.ogv?alt=media"}');
-          assert.equal(JSON.stringify(response.detail.files[1]),
-            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fsouth-park.webm?alt=media"}');
-          assert.equal(JSON.stringify(response.detail.files[2]),
-            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcar-ad.mp4?alt=media"}');
+        var listener = function(response) {
+          assert.include(JSON.stringify(response.detail.files[0]),
+            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fwalking-dead.ogv?alt=media&cb=');
+          assert.include(JSON.stringify(response.detail.files[1]),
+            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fsouth-park.webm?alt=media&cb=');
+          assert.include(JSON.stringify(response.detail.files[2]),
+            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcar-ad.mp4?alt=media&cb=');
           sorting.removeEventListener("rise-storage-response", listener);
         };
 
@@ -70,13 +70,13 @@
       });
 
       test("should sort in ascending order by date", function(done) {
-        listener = function(response) {
-          assert.equal(JSON.stringify(response.detail.files[0]),
-            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fwalking-dead.ogv?alt=media"}');
-          assert.equal(JSON.stringify(response.detail.files[1]),
-            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcar-ad.mp4?alt=media"}');
-          assert.equal(JSON.stringify(response.detail.files[2]),
-            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fsouth-park.webm?alt=media"}');
+        var listener = function(response) {
+          assert.include(JSON.stringify(response.detail.files[0]),
+            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fwalking-dead.ogv?alt=media&cb=');
+          assert.include(JSON.stringify(response.detail.files[1]),
+            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcar-ad.mp4?alt=media&cb=');
+          assert.include(JSON.stringify(response.detail.files[2]),
+            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fsouth-park.webm?alt=media&cb=');
           sorting.removeEventListener("rise-storage-response", listener);
         };
 
@@ -89,13 +89,13 @@
       });
 
       test("should sort in descending order by date", function(done) {
-        listener = function(response) {
-          assert.equal(JSON.stringify(response.detail.files[0]),
-            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fsouth-park.webm?alt=media"}');
-          assert.equal(JSON.stringify(response.detail.files[1]),
-            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcar-ad.mp4?alt=media"}');
-          assert.equal(JSON.stringify(response.detail.files[2]),
-            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fwalking-dead.ogv?alt=media"}');
+        var listener = function(response) {
+          assert.include(JSON.stringify(response.detail.files[0]),
+            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fsouth-park.webm?alt=media&cb=');
+          assert.include(JSON.stringify(response.detail.files[1]),
+            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcar-ad.mp4?alt=media&cb=');
+          assert.include(JSON.stringify(response.detail.files[2]),
+            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fwalking-dead.ogv?alt=media&cb=');
           sorting.removeEventListener("rise-storage-response", listener);
         };
 
@@ -107,7 +107,7 @@
       });
 
       test("should sort in random order", function(done) {
-        listener = function(response) {
+        var listener = function(response) {
           /* Not possible to predict what order files will be returned in,
           only that they are returned. */
           assert.equal(response.detail.files.length, 3);
@@ -122,13 +122,13 @@
       });
 
       test("should sort in ascending order when no sortDirection is specified", function(done) {
-        listener = function(response) {
-          assert.equal(JSON.stringify(response.detail.files[0]),
-            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fwalking-dead.ogv?alt=media"}');
-          assert.equal(JSON.stringify(response.detail.files[1]),
-            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcar-ad.mp4?alt=media"}');
-          assert.equal(JSON.stringify(response.detail.files[2]),
-            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fsouth-park.webm?alt=media"}');
+        var listener = function(response) {
+          assert.include(JSON.stringify(response.detail.files[0]),
+            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fwalking-dead.ogv?alt=media&cb=');
+          assert.include(JSON.stringify(response.detail.files[1]),
+            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcar-ad.mp4?alt=media&cb=');
+          assert.include(JSON.stringify(response.detail.files[2]),
+            '{"url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fsouth-park.webm?alt=media&cb=');
           sorting.removeEventListener("rise-storage-response", listener);
         };
 

--- a/test/rise-storage.html
+++ b/test/rise-storage.html
@@ -14,17 +14,14 @@
   <rise-storage id="noCompany"></rise-storage>
   <rise-storage id="bucket" companyId="abc123"></rise-storage>
   <rise-storage id="folder" companyId="abc123" folder="my-folder"></rise-storage>
-  <rise-storage id="file" companyId="abc123" fileName="circle.png"></rise-storage>
-  <rise-storage id="file-folder" companyId="abc123" folder="my-folder" fileName="circle.png"></rise-storage>
 
   <script src="js/rise-storage-data.js"></script>
   <script>
     suite("rise-storage", function() {
-      var noCompany = document.querySelector("#noCompany"),
+      var responded,
+        noCompany = document.querySelector("#noCompany"),
         bucket = document.querySelector("#bucket"),
-        folder = document.querySelector("#folder"),
-        file = document.querySelector("#file"),
-        fileFolder = document.querySelector("#file-folder");
+        folder = document.querySelector("#folder");
 
       suiteSetup(function() {
         xhr = sinon.useFakeXMLHttpRequest();
@@ -40,6 +37,7 @@
 
       setup(function() {
         requests = [];
+        responded = false;
       });
 
       suite("initialization", function() {
@@ -59,8 +57,6 @@
           assert.equal(noCompany.url, "");
           assert.equal(bucket.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o?delimiter=%2F");
           assert.equal(folder.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o?delimiter=%2F&prefix=my-folder/");
-          assert.equal(file.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/circle.png");
-          assert.equal(fileFolder.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o?delimiter=%2F&prefix=my-folder/circle.png");
         });
       });
 
@@ -74,7 +70,7 @@
         });
 
         test("should get files when companyId is added dynamically", function(done) {
-          listener = function(response) {
+          var listener = function(response) {
             assert.equal(response.detail.files.length, 2);
             noCompany.removeEventListener("rise-storage-response", listener);
           };
@@ -86,94 +82,11 @@
           done();
         });
 
-        test("should get files in a bucket", function(done) {
-          listener = function(response) {
-            assert.equal(response.detail.files.length, 2);
-            bucket.removeEventListener("rise-storage-response", listener);
-          };
-
-          bucket.addEventListener("rise-storage-response", listener);
-          bucket.pingReceived = true;
-          bucket.go();
-          requests[0].respond(200, header, bucketFiles);
-          done();
-        });
-
-        test("should get files in a folder", function(done) {
-          listener = function(response) {
-            assert.equal(response.detail.files.length, 8);
-            folder.removeEventListener("rise-storage-response", listener);
-          };
-
-          folder.addEventListener("rise-storage-response", listener);
-          folder.go();
-          requests[0].respond(200, header, folderFiles);
-          done();
-        });
-
-        test("should get a specific file in a bucket", function(done) {
-          listener = function(response) {
-            assert.equal(response.detail.files.length, 1);
-            file.removeEventListener("rise-storage-response", listener);
-          };
-
-          file.addEventListener("rise-storage-response", listener);
-          file.go();
-          requests[0].respond(200, header, bucketFile);
-          done();
-        });
-
-        test("should get a specific file in a folder", function(done) {
-          listener = function(response) {
-            assert.equal(response.detail.files.length, 1);
-            fileFolder.removeEventListener("rise-storage-response", listener);
-          };
-
-          fileFolder.addEventListener("rise-storage-response", listener);
-          fileFolder.go();
-          requests[0].respond(200, header, folderFile);
-          done();
-        });
-
         test("should use correct URL after attribute change", function(done) {
           folder.setAttribute("fileName", "circle.png");
           folder.go();
           assert.equal(folder.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o?delimiter=%2F&prefix=my-folder/circle.png");
           folder.removeAttribute("fileName");
-          done();
-        });
-      });
-
-      suite("response", function() {
-        var responded;
-
-        setup(function() {
-          responded = false;
-        });
-
-        test("should fire rise-storage-response on success", function(done) {
-          listener = function(response) {
-            responded = true;
-            bucket.removeEventListener("rise-storage-response", listener);
-          };
-
-          bucket.addEventListener("rise-storage-response", listener);
-          bucket.go();
-          requests[0].respond(200, header, bucketFile);
-          assert.isTrue(responded);
-          done();
-        });
-
-        test("should not fire rise-storage-response on failure", function(done) {
-          listener = function(response) {
-            responded = true;
-            bucket.removeEventListener("rise-storage-response", listener);
-          };
-
-          bucket.addEventListener("rise-storage-response", listener);
-          bucket.go();
-          requests[0].respond(404, header, bucketFile);
-          assert.isFalse(responded);
           done();
         });
       });


### PR DESCRIPTION
* Append a cache buster to all URLs. The component keeps track of what the previous URLs were so that if the `etag` property hasn't changed on the next request, it can use the previous URL.
* Move some test cases from `rise-storage.html` to `rise-storage-bucket.html` and `rise-storage-folder.html`.
* Version bump.