### PR TITLE
Use Rise Storage's API

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "authors": [
     "Donna Peplinskie <donna.peplinskie@risevision.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-component-rise-storage",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "The Rise Storage Web Component uses Google’s storage API to retrieve the URLs of all files in a particular folder, or the URL of a single file in a particular folder, from Rise Storage.",
   "scripts": {
     "test": "gulp test",

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -239,7 +239,11 @@
      * An instance of the element was inserted into the DOM.
      */
     attached: function() {
-      this.$.ping.generateRequest();
+      var self = this;
+
+      setTimeout(function() {
+        self.$.ping.generateRequest();
+      }, 1000);
     },
 
     /***************************************** STORAGE ******************************************/
@@ -248,9 +252,9 @@
      * Sets the URL that is used for making requests to Storage.
      */
     _computeStorageUrl: function() {
-      var baseUrl = "https://www.googleapis.com/storage/v1/b/risemedialibrary-" + encodeURIComponent(this.companyid) + "/o",
-        delimiter = "?delimiter=" + encodeURIComponent("/"),
-        folder = "&prefix=" + encodeURIComponent(this.folder),
+      //var baseUrl = "https://storage-dot-rvacore-test.appspot.com/_ah/api/storage/v0.01/files?companyId=" + encodeURIComponent(this.companyid),
+      var baseUrl = "https://storage-dot-rvaserver2.appspot.com/_ah/api/storage/v0.01/files?companyId=" + encodeURIComponent(this.companyid),
+        folder = encodeURIComponent(this.folder),
         filename = encodeURIComponent(this.filename),
         url = baseUrl;
 
@@ -263,20 +267,16 @@
 
           // Get a specific file in a specific folder.
           if (this.filename) {
-            url += delimiter + folder + filename;
+            url += "&file=" + folder + filename;
           }
           // Get all files in a specific folder.
           else {
-            url += delimiter + folder;
+            url += "&folder=" + folder;
           }
         }
         // Get a specific file in a bucket.
         else if (this.filename) {
-          url += "/" + filename;
-        }
-        // Get all files in a bucket.
-        else {
-          url += delimiter;
+          url += "&file=" + filename;
         }
 
         this.$.storage.url = url;
@@ -288,6 +288,11 @@
      */
     _handleStorageResponse: function(e, resp) {
       if (resp && resp.response) {
+        if(resp.response.files) {
+          resp.response.items = resp.response.files;
+          delete resp.response.files;
+        }
+
         if (this._isLoading) {
           this._setIsFile(resp.response);
         }

--- a/test/integration/rise-storage-integration.html
+++ b/test/integration/rise-storage-integration.html
@@ -241,6 +241,8 @@
         setup(function() {
           fileType._isCacheRunning = false;
           fileType._pingReceived = true;
+          contentType._isCacheRunning = false;
+          contentType._pingReceived = true;
         });
 
         teardown(function() {

--- a/test/unit/rise-storage-unit.html
+++ b/test/unit/rise-storage-unit.html
@@ -86,28 +86,28 @@
 
         test("should correctly set Storage request URL for a folder", function() {
           folder._computeStorageUrl();
-          assert.equal(folder.$.storage.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o?delimiter=%2F&prefix=images/");
+          assert.equal(folder.$.storage.url, "https://storage-dot-rvaserver2.appspot.com/_ah/api/storage/v0.01/files?companyId=abc123&folder=images/");
         });
 
         test("should correctly set Storage request URL for a file in a folder", function() {
           fileFolder._computeStorageUrl();
-          assert.equal(fileFolder.$.storage.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o?delimiter=%2F&prefix=images/home.jpg");
+          assert.equal(fileFolder.$.storage.url, "https://storage-dot-rvaserver2.appspot.com/_ah/api/storage/v0.01/files?companyId=abc123&file=images/home.jpg");
         });
 
         test("should correctly set Storage request URL for a bucket", function() {
           bucket._computeStorageUrl();
-          assert.equal(bucket.$.storage.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o?delimiter=%2F");
+          assert.equal(bucket.$.storage.url, "https://storage-dot-rvaserver2.appspot.com/_ah/api/storage/v0.01/files?companyId=abc123");
         });
 
         test("should correctly set Storage request URL for a file in a bucket", function() {
           fileBucket._computeStorageUrl();
-          assert.equal(fileBucket.$.storage.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg");
+          assert.equal(fileBucket.$.storage.url, "https://storage-dot-rvaserver2.appspot.com/_ah/api/storage/v0.01/files?companyId=abc123&file=home.jpg");
         });
 
         test("should correctly set Storage request URL for a folder that ends with a /", function() {
           folder.setAttribute("folder", "images/");
           folder._computeStorageUrl();
-          assert.equal(folder.$.storage.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o?delimiter=%2F&prefix=images%2F");
+          assert.equal(folder.$.storage.url, "https://storage-dot-rvaserver2.appspot.com/_ah/api/storage/v0.01/files?companyId=abc123&folder=images%2F");
         });
       });
 


### PR DESCRIPTION
This PR changes requests from using Google Cloud Storage API to Rise Storage's one. There are no changes regarding how each individual file is handled, since the returned fields are the same.

The most important point, and probably something we should discuss, is the fact that the environment is now important. Google API was consuming information directly from GCS buckets, which do not depend on whether rvacore-test or rvaserver2 is being used. Storage API relies on information from Datastore, which makes it environment dependent (company information belongs to a specific environment). For the moment storage component points to production, but maybe having a configuration property to set which environment it should use would be a good idea.

@stulees @donnapep @tejohnso please review