### PR TITLE
Send one notification message per file

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Next, construct your HTML page. You should include `webcomponents.js` before any
 
         // Respond to events it fires.
         storage.addEventListener('rise-storage-response', function(e) {
-          if (e.detail && e.detail.files && e.detail.files.length > 0) {
-            console.log(e.detail.files[0].url); // URL to the file.
+          if (e.detail) {
+            console.log(e.detail.url); // URL to the file.
           }
         });
 
@@ -83,25 +83,13 @@ You can get the `companyId` by copying the value of the `cid` parameter in the U
 
 ![company-id](https://cloud.githubusercontent.com/assets/1190420/7048788/0835e2e2-dde3-11e4-9b25-8e4365541351.png)
 
-The web component returns a JSON response with the following format:
+The web component returns a JSON response for each file matching the provided criteria with the following format (one message per file):
 ```
 {
-  "files": [
-    "url": "http://url.to.file",
-    "timeline": {
-      carryon: "false",
-      duration: 60,
-      endDate: "01/31/15 12:00 AM",
-      endTime: null,
-      pud: "false",
-      recurrenceOptions: null,
-      startDate: "01/30/15 12:00 AM",
-      startTime: null,
-      timeDefined: true,
-      trash: "false",
-      type: "TIMELINE"
-    }
-  ]
+  "url": "http://url.to.file",
+  "added": "boolean indicating if the file has just been added",
+  "changed": "boolean indicating if the file has changed since the previous message",
+  "deleted": "boolean indicating if the file has been deleted since the previous message",
 }
 ```
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "authors": [
     "Donna Peplinskie <donna.peplinskie@risevision.com>"
   ],

--- a/demo.html
+++ b/demo.html
@@ -10,21 +10,40 @@
 </head>
 <body unresolved>
   <rise-storage id="sorting" companyId="b428b4e8-c8b9-41d5-8a10-b4193c789443" folder="images"
-    sort="name" sortDirection="desc"></rise-storage>
-  <img id="image1" src="" />
-  <img id="image2" src="" />
-  <img id="image3" src="" />
+    sort="name" sortDirection="desc" fileType="image"></rise-storage>
+  <div id="imagesContainer"></div>
 
   <script>
-    var storage = document.querySelector("rise-storage"),
-      image1 = document.querySelector("#image1"),
-      image2 = document.querySelector("#image2"),
-      image3 = document.querySelector("#image3");
+    var files = [];
+    var imagesContainer = document.querySelector("#imagesContainer");
+    var storage = document.querySelector("rise-storage");
 
     storage.addEventListener("rise-storage-response", function(e) {
-      image1.setAttribute("src", e.detail.files[0].url);
-      image2.setAttribute("src", e.detail.files[1].url);
-      image3.setAttribute("src", e.detail.files[2].url);
+      var file = e.detail;
+      var existing = files.filter(function(f) {
+        return file.name === f.name;
+      });
+
+      existing = existing.length > 0 ? existing[0] : null;
+
+      if(file.added) {
+        files.push(file);
+      }
+      else if(file.changed && existing) {
+        existing.url = file.url;
+      }
+      else if(file.deleted && existing) {
+        files.splice(files.indexOf(existing), 1);
+      }
+
+      imagesContainer.innerHTML = "";
+
+      files.forEach(function(file) {
+        var image = document.createElement("img");
+
+        image.src = file.url;
+        imagesContainer.appendChild(image);
+      });
     });
   </script>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-component-rise-storage",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "The Rise Storage Web Component uses Google’s storage API to retrieve the URLs of all files in a particular folder, or the URL of a single file in a particular folder, from Rise Storage.",
   "scripts": {
     "test": "gulp test",

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -207,15 +207,6 @@
     _totalFilesBefore: 0,
 
     /**
-     * Stores details about a particular file in a folder.
-     *
-     * @property _files
-     * @type object
-     * @default []
-     */
-    _files: [],
-
-    /**
      * Whether or not any of the files in a folder have changed.
      *
      * @property _isChanged
@@ -239,11 +230,7 @@
      * An instance of the element was inserted into the DOM.
      */
     attached: function() {
-      var self = this;
-
-      setTimeout(function() {
-        self.$.ping.generateRequest();
-      }, 1000);
+      this.$.ping.generateRequest();
     },
 
     /***************************************** STORAGE ******************************************/
@@ -339,7 +326,6 @@
      */
     _handleStorageFile: function(resp) {
       var file = {},
-        files = [],
         etag = null;
 
       // File in the root of the bucket.
@@ -355,8 +341,11 @@
 
       if (this._isLoading) {
         this._items.push({
+          "name": this.filename,
           "etag": etag
         });
+
+        file.added = true;
 
         this._isLoading = false;
       }
@@ -370,11 +359,11 @@
         else {
           this._items[0].etag = etag;
           file.url += "&cb=" + new Date().getTime();
+          file.changed = true;
         }
       }
 
-      files.push(file);
-      this.fire("rise-storage-response", this._prepareResponse(files));
+      this.fire("rise-storage-response", file);
       this._startTimer();
     },
 
@@ -384,12 +373,32 @@
     _handleStorageFolder: function(resp) {
       var self = this,
         file = {},
-        files = [],
         previousItem = null,
         suffix = "?alt=media",
         cb = "&cb=" + new Date().getTime();
 
       if (resp.items) {
+        if (this.sort) {
+          resp.items.forEach(function(item) {
+            // Sorting
+            if (self.sort) {
+              if (self.sort === "name") {
+                item.sortBy = item.name;
+              }
+              else if (self.sort === "date") {
+                item.sortBy = new Date(item.updated).getTime();
+              }
+            }
+          });
+
+          resp.items = this._sortFiles(resp.items);
+          resp.items.forEach(function(item) {
+            if (self.sort) {
+              delete item.sortBy;
+            }
+          });
+        }
+
         resp.items.forEach(function(item) {
           file = {};
 
@@ -398,16 +407,6 @@
             if (item.selfLink !== undefined) {
               if (!self._filterFiles(item.contentType)) {
                 return;
-              }
-
-              // Sorting
-              if (self.sort) {
-                if (self.sort === "name") {
-                  file.sortBy = item.name;
-                }
-                else if (self.sort === "date") {
-                  file.sortBy = new Date(item.updated).getTime();
-                }
               }
 
               if (self._isLoading) {
@@ -424,6 +423,8 @@
                   "etag": item.etag,
                   "url": file.url
                 });
+
+                file.added = true;
               }
               else {
                 // Construct URL.
@@ -445,6 +446,8 @@
                     "etag": item.etag,
                     "url": file.url
                   });
+
+                  file.added = true;
                 }
                 // Existing file
                 else {
@@ -456,24 +459,32 @@
                     if (!self._isCacheRunning) {
                       file.url = previousItem.url;
                     }
+
+                    file.unchanged = true;
                   }
                   // File has changed.
                   else {
                     previousItem.etag = item.etag;
                     previousItem.url = file.url;
+
+                    file.changed = true;
                   }
                 }
               }
 
-              files.push(file);
+              if (self.sort) {
+                delete file.sortBy;
+              }
+
+              if(!file.unchanged) {
+                self.fire("rise-storage-response", file);
+              }
             }
           }
         });
 
+        this._processRemovedFiles(resp.items);
         this._isLoading = false;
-        // Clean up files from this._items that are no longer in the folder.
-        // Remove all this._items that are not in response.items. Use name field as the id.
-        this.fire("rise-storage-response", this._prepareResponse(files));
         this._startTimer();
       }
     },
@@ -504,12 +515,14 @@
 
       if (resp.items) {
         this._numFiles = 0;
-        this._files = [];
         this._isChanged = false;
         this._totalFilesBefore = this._totalFiles;
 
         // One item is the folder itself.
         this._totalFiles = resp.items.length - 1;
+
+        // Remove no longer existing files
+        this._processRemovedFiles(resp.items);
 
         resp.items.forEach(function(item) {
           // Check that current item is not a folder.
@@ -544,7 +557,6 @@
      */
     _handleCacheFile: function(resp) {
       var file = {},
-        files = [],
         lastModified = "";
 
       if (resp && resp.xhr) {
@@ -554,8 +566,11 @@
         if (this._isLoading) {
           // Save Last Modified so it can be compared in subsequent requests.
           this._items.push({
+            "name": this.filename,
             "lastModified": lastModified
           });
+
+          file.added = true;
 
           if (lastModified === null) {
             console.log("File does not have a Last-Modified header: " + file.url);
@@ -566,17 +581,19 @@
         else {
           // Rise Cache file hasn't changed.
           if (this._items[0].lastModified === lastModified) {
+            file.unchanged = true;
             this._startTimer();
 
             return;
           }
           else {
             this._items[0].lastModified = lastModified;
+            this.changed = true;
+            file.changed = true;
           }
         }
 
-        files.push(file);
-        this.fire("rise-storage-response", this._prepareResponse(files));
+        this.fire("rise-storage-response", file);
       }
 
       this._startTimer();
@@ -609,10 +626,13 @@
         if (this._isLoading) {
           // Save file details so they can be compared in subsequent requests.
           this._items.push({
+            "name": this._getFileNameFromUrl(url),
             "lastModified": lastModified,
             "fullUrl": file.url,
             "url": url
           });
+
+          file.added = true;
 
           if (lastModified === null) {
             console.log("File does not have a Last-Modified header: " + file.url);
@@ -626,27 +646,34 @@
           // New file
           if (previousItem === undefined) {
             this._items.push({
+              "name": this._getFileNameFromUrl(url),
               "lastModified": lastModified,
               "fullUrl": file.url,
               "url": url
             });
+
+            file.added = true;
           }
           // Existing file
           else {
             if (lastModified === previousItem.lastModified) {
               // Use the same URL as before in order to leverage browser caching.
               file.url = previousItem.fullUrl;
+              file.unchanged = true;
             }
             // File has changed.
             else {
               previousItem.lastModified = lastModified;
               previousItem.fullUrl = file.url;
               this._isChanged = true;
+              file.changed = true;
             }
           }
         }
 
-        this._files.push(file);
+        if(!file.unchanged) {
+          this.fire("rise-storage-response", file);
+        }
       }
 
       this._numFiles++;
@@ -656,10 +683,6 @@
         // or removed.
         if (this._totalFiles !== this._totalFilesBefore) {
           this._isChanged = true;
-        }
-
-        if (this._isLoading || this._isChanged) {
-          this.fire("rise-storage-response", this._prepareResponse(this._files));
         }
 
         this._startTimer();
@@ -697,6 +720,27 @@
       this._isCacheRunning = false;
       this._pingReceived = true;
       this.go();
+    },
+
+    /**
+     * Removes no longer existing files from the local list and notifies clients about the deletion
+     */
+    _processRemovedFiles: function(latestFilesList) {
+      function fileExists(file) {
+        return latestFilesList.some(function(element) {
+          return file.name === element.name;
+        });
+      }
+
+      for(var i = this._items.length - 1; i >= 0; i--) {
+        var file = this._items[i];
+
+        if(!fileExists(file)) {
+          this._items.splice(i, 1);
+          file.deleted = true;
+          this.fire("rise-storage-response", file);
+        }
+      }
     },
 
     /****************************************** COMMON ******************************************/
@@ -868,27 +912,46 @@
     },
 
     /**
-     * Prepares the response object.
+     * Returns the path of a file in a given bucket, excluding bucket name and parameters
      */
-    _prepareResponse: function(files) {
-      var self = this,
-        response = {};
-
-      response.files = [];
-
-      if (this.sort && files.length > 0) {
-        files = this._sortFiles(files);
+    _getFileNameFromUrl: function(fileUrl) {
+      if(!fileUrl) {
+        return null;
       }
+      else {
+        var url = decodeURIComponent(fileUrl);
+        var start = url.indexOf("/", "https://storage.googleapis.com/".length);
+        var end = url.lastIndexOf("?");
 
-      files.forEach(function(file) {
-        if (self.sort) {
-          delete file.sortBy;
+        if(start === -1) {
+          return url;
         }
+        else if(end > 0 && end > start) {
+          return url.substring(start + 1, end);
+        }
+        else {
+          return url.substring(start + 1);
+        }
+      }
+    },
 
-        response.files.push(file);
-      });
-
-      return response;
+    /**
+     * Initializes internal properties to their default state
+     */
+    _reset: function() {
+      this._isLoading = true;
+      this._isFile = true;
+      this._cacheUrl = "";
+      this._fileUrl = "";
+      this._items = [];
+      this._isCacheRunning = false;
+      this._pingReceived = false;
+      this._numFiles = 0;
+      this._totalFiles = 0;
+      this._totalFilesBefore = 0;
+      this._isChanged = false;
     }
+
+
   });
 </script>

--- a/test/integration/rise-storage-integration.html
+++ b/test/integration/rise-storage-integration.html
@@ -38,7 +38,6 @@
       // Runs for every suite.
       suiteSetup(function() {
         server = sinon.fakeServer.create();
-        server.respondImmediately = true;
 
         // Send a response to the ping request.
         server.respondWith("GET", "http://localhost:9494/ping?callback=_handlePingResponse",
@@ -65,13 +64,14 @@
 
         test("should return the correct URL for a specific file in a bucket", function(done) {
           responseHandler = function(response) {
-            assert.equal(response.detail.files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media");
+            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media");
             done();
           };
 
           file.addEventListener("rise-storage-response", responseHandler);
           server.respondWith([200, header, JSON.stringify(bucketImage)]);
           file.go();
+          server.respond();
         });
 
         test("should not fire rise-storage-response if the file hasn't changed", function(done) {
@@ -80,6 +80,7 @@
           file.addEventListener("rise-storage-response", responseHandler);
           server.respondWith([200, header, JSON.stringify(bucketImage)]);
           file.go();
+          server.respond();
 
           assert(responseHandler.notCalled);
           done();
@@ -87,38 +88,45 @@
 
         test("should return a new URL if the file has changed", function(done) {
           responseHandler = function(response) {
-            assert.equal(response.detail.files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media&cb=0");
+            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media&cb=0");
             done();
           };
 
-          bucketImage.etag = "new";
+          var localBucketImage = JSON.parse(JSON.stringify(bucketImage));
+          localBucketImage.etag = "new";
 
           file.addEventListener("rise-storage-response", responseHandler);
-          server.respondWith([200, header, JSON.stringify(bucketImage)]);
+          server.respondWith([200, header, JSON.stringify(localBucketImage)]);
           file.go();
+          server.respond();
         });
       });
 
       suite("file in a folder", function() {
+        var localFolderImage;
+
         setup(function() {
+          fileFolder._reset();
           fileFolder._isCacheRunning = false;
           fileFolder._pingReceived = true;
+          localFolderImage = JSON.parse(JSON.stringify(folderImage));
         });
 
         teardown(function() {
-          folderImage.items[0].etag = "COjLvarr/cQCEAE=";
+          folderImage = localFolderImage;
           fileFolder.removeEventListener("rise-storage-response", responseHandler);
         });
 
         test("should return the correct URL for a specific file in a folder", function(done) {
           responseHandler = function(response) {
-            assert.equal(response.detail.files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
+            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
             done();
           };
 
           fileFolder.addEventListener("rise-storage-response", responseHandler);
           server.respondWith([200, header, JSON.stringify(folderImage)]);
           fileFolder.go();
+          server.respond();
         });
 
         test("should not fire rise-storage-response if the file hasn't changed", function(done) {
@@ -127,84 +135,128 @@
           fileFolder.addEventListener("rise-storage-response", responseHandler);
           server.respondWith([200, header, JSON.stringify(folderImage)]);
           fileFolder.go();
+          server.respond();
 
           assert(responseHandler.notCalled);
           done();
         });
 
         test("should return a new URL if the file has changed", function(done) {
-          responseHandler = function(response) {
-            assert.equal(response.detail.files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&cb=0");
-            done();
-          };
+          var files = [];
 
-          folderImage.items[0].etag = "new";
+          responseHandler = function(response) {
+            files.push(response.detail);
+
+            if(files.length === 2) {
+              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
+              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&cb=0");
+              assert.isTrue(files[0].added);
+              assert.isTrue(files[1].changed);
+              done();
+            }
+          };
 
           fileFolder.addEventListener("rise-storage-response", responseHandler);
           server.respondWith([200, header, JSON.stringify(folderImage)]);
           fileFolder.go();
+          server.respond();
+
+          folderImage.items[0].etag = "new";
+
+          server.respondWith([200, header, JSON.stringify(folderImage)]);
+          fileFolder.go();
+          server.respond();
         });
       });
 
       suite("folder", function() {
+        var localImages;
+
         setup(function() {
+          folder._reset();
           folder._isCacheRunning = false;
           folder._pingReceived = true;
+          localImages = JSON.parse(JSON.stringify(images));
         });
 
         teardown(function() {
-          images.items[2].etag = "CMiEudSn2MMCEAs=";
+          images = localImages;
           folder.removeEventListener("rise-storage-response", responseHandler);
         });
 
         test("should return the correct URLs for files in a folder", function(done) {
+          var files = [];
+
           responseHandler = function(response) {
-            assert.equal(response.detail.files.length, 3);
-            assert.equal(response.detail.files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
-            assert.equal(response.detail.files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media");
-            assert.equal(response.detail.files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media");
-            done();
+            files.push(response.detail);
+
+            if(files.length === 3) {
+              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
+              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media");
+              assert.equal(files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media");
+              done();
+            }
           };
 
           folder.addEventListener("rise-storage-response", responseHandler);
           server.respondWith([200, header, JSON.stringify(images)]);
           folder.go();
+          server.respond();
         });
 
-        test("should return the same URLs if none of the files have changed", function(done) {
-          responseHandler = function(response) {
-            assert.equal(response.detail.files.length, 3);
-            assert.equal(response.detail.files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
-            assert.equal(response.detail.files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media");
-            assert.equal(response.detail.files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media");
-            done();
-          };
+        test("should not send notifications if none of the files have changed", function(done) {
+          responseHandler = sinon.spy();
 
           folder.addEventListener("rise-storage-response", responseHandler);
           server.respondWith([200, header, JSON.stringify(images)]);
           folder.go();
+          server.respond();
+
+          assert(responseHandler.notCalled);
+          done();
         });
 
         test("should return a new URL if a file has changed", function(done) {
+          var files = [];
+
           responseHandler = function(response) {
-            assert.equal(response.detail.files.length, 3);
-            assert.equal(response.detail.files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&cb=0");
-            done();
+            files.push(response.detail);
+
+            if(files.length === 4) {
+              assert.equal(files[3].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&cb=0");
+              assert.isTrue(files[3].changed);
+              done();
+            }
           };
+
+          server.respondWith([200, header, JSON.stringify(images)]);
+          folder.addEventListener("rise-storage-response", responseHandler);
+          folder.go();
+          server.respond();
 
           images.items[2].etag = "new";
 
-          folder.addEventListener("rise-storage-response", responseHandler);
           server.respondWith([200, header, JSON.stringify(images)]);
           folder.go();
+          server.respond();
         });
 
         test("should return URL of a file that has been added to a folder", function(done) {
+          var files = [];
+
           responseHandler = function(response) {
-            assert.equal(response.detail.files.length, 4);
-            assert.equal(response.detail.files[3].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&cb=0");
-            done();
+            files.push(response.detail);
+
+            if(files.length === 4) {
+              assert.equal(files[3].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&cb=0");
+              done();
+            }
           };
+
+          server.respondWith([200, header, JSON.stringify(images)]);
+          folder.addEventListener("rise-storage-response", responseHandler);
+          folder.go();
+          server.respond();
 
           images.items.push({
             "name": "images/golf.svg",
@@ -214,33 +266,49 @@
             "etag": "CPjC1qHc7MQCEAE="
           });
 
-          folder.addEventListener("rise-storage-response", responseHandler);
           server.respondWith([200, header, JSON.stringify(images)]);
           folder.go();
+          server.respond();
         });
 
         test("should not return URL of a file that has been removed from a folder", function(done) {
-          responseHandler = function(response) {
-            assert.equal(response.detail.files.length, 3);
-            assert.equal(response.detail.files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
-            assert.equal(response.detail.files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&cb=0");
-            assert.equal(response.detail.files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media");
+          var files = [];
 
-            done();
+          responseHandler = function(response) {
+            files.push(response.detail);
+
+            if(files.length === 4) {
+              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
+              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media");
+              assert.equal(files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media");
+              assert.equal(files[3].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media");
+              assert.isTrue(files[3].deleted);
+              done();
+            }
+            else if(files.length > 4) {
+              assert.isTrue(false);
+            }
           };
+
+          server.respondWith([200, header, JSON.stringify(images)]);
+          folder.addEventListener("rise-storage-response", responseHandler);
+          folder.go();
+          server.respond();
 
           images.items.pop();
 
-          folder.addEventListener("rise-storage-response", responseHandler);
           server.respondWith([200, header, JSON.stringify(images)]);
           folder.go();
+          server.respond();
         });
       });
 
       suite("filtering", function() {
         setup(function() {
+          fileType._reset();
           fileType._isCacheRunning = false;
           fileType._pingReceived = true;
+          contentType._reset();
           contentType._isCacheRunning = false;
           contentType._pingReceived = true;
         });
@@ -251,32 +319,45 @@
         });
 
         test("should return only images when filtering by fileType", function(done) {
+          var files = [];
+
           responseHandler = function(response) {
-            assert.equal(response.detail.files.length, 5);
-            done();
+            files.push(response.detail);
+
+            if(files.length === 5) {
+              done();
+            }
           };
 
           fileType.addEventListener("rise-storage-response", responseHandler);
           server.respondWith([200, header, JSON.stringify(mixedMedia)]);
           fileType.go();
+          server.respond();
         });
 
         test("should return only image/jpeg and image/bmp files when filtering by contentType", function(done) {
+          var files = [];
+
           responseHandler = function(response) {
-            assert.equal(response.detail.files.length, 2);
-            assert.equal(response.detail.files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
-            assert.equal(response.detail.files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media");
-            done();
+            files.push(response.detail);
+
+            if(files.length === 2) {
+              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
+              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media");
+              done();
+            }
           };
 
           contentType.addEventListener("rise-storage-response", responseHandler);
           server.respondWith([200, header, JSON.stringify(mixedMedia)]);
           contentType.go();
+          server.respond();
         });
       });
 
       suite("Rise Cache - bucket file", function() {
         setup(function() {
+          cacheFile._reset();
           cacheFile._isCacheRunning = true;
           cacheFile._pingReceived = true;
           cacheFile._fileUrl = "https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fhome.jpg";
@@ -288,13 +369,14 @@
 
         test("should return the correct URL for a specific file in a bucket", function(done) {
           responseHandler = function(response) {
-            assert.equal(response.detail.files[0].url, "http://localhost:9494/?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fhome.jpg");
+            assert.equal(response.detail.url, "http://localhost:9494/?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fhome.jpg");
             done();
           };
 
           cacheFile.addEventListener("rise-storage-response", responseHandler);
           server.respondWith([200, cacheHeader, ""]);
           cacheFile._getFileFromCache();
+          server.respond();
         });
 
         test("should not fire rise-storage-response if the file hasn't changed", function(done) {
@@ -303,6 +385,7 @@
           cacheFile.addEventListener("rise-storage-response", responseHandler);
           server.respondWith([200, cacheHeader, ""]);
           cacheFile._getFileFromCache();
+          server.respond();
 
           assert(responseHandler.notCalled);
           done();
@@ -310,18 +393,25 @@
 
         test("should return a new URL if the file has changed", function(done) {
           responseHandler = function(response) {
-            assert.equal(response.detail.files[0].url, "http://localhost:9494/cb=0?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fhome.jpg");
+            assert.equal(response.detail.url, "http://localhost:9494/cb=0?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fhome.jpg");
             done();
           };
 
+          cacheFile._items.push({
+            "name": "home.jpg", "lastModified": ""
+          });
+
+          cacheFile._isLoading = false;
           cacheFile.addEventListener("rise-storage-response", responseHandler);
           server.respondWith([200, newCacheHeader, ""]);
           cacheFile._getFileFromCache();
+          server.respond();
         });
       });
 
       suite("Rise Cache - folder file", function() {
         setup(function() {
+          cacheFileFolder._reset();
           cacheFileFolder._isCacheRunning = true;
           cacheFileFolder._pingReceived = true;
           cacheFileFolder._fileUrl = "https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fimages%252Fhome.jpg";
@@ -333,13 +423,14 @@
 
         test("should return the correct URL for a specific file in a folder", function(done) {
           responseHandler = function(response) {
-            assert.equal(response.detail.files[0].url, "http://localhost:9494/?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fimages%252Fhome.jpg");
+            assert.equal(response.detail.url, "http://localhost:9494/?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fimages%252Fhome.jpg");
             done();
           };
 
-          cacheFileFolder.addEventListener("rise-storage-response", responseHandler);
           server.respondWith([200, cacheHeader, ""]);
+          cacheFileFolder.addEventListener("rise-storage-response", responseHandler);
           cacheFileFolder._getFileFromCache();
+          server.respond();
         });
 
         test("should not fire rise-storage-response if the file hasn't changed", function(done) {
@@ -348,6 +439,7 @@
           cacheFileFolder.addEventListener("rise-storage-response", responseHandler);
           server.respondWith([200, cacheHeader, ""]);
           cacheFileFolder._getFileFromCache();
+          server.respond();
 
           assert(responseHandler.notCalled);
           done();
@@ -355,13 +447,19 @@
 
         test("should return a new URL if the file has changed", function(done) {
           responseHandler = function(response) {
-            assert.equal(response.detail.files[0].url, "http://localhost:9494/cb=0?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fimages%252Fhome.jpg");
+            assert.equal(response.detail.url, "http://localhost:9494/cb=0?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fimages%252Fhome.jpg");
             done();
           };
 
+          cacheFileFolder._items.push({
+            "name": "risemedialibrary-abc123/images/home.jpg", "lastModified": ""
+          });
+
+          cacheFileFolder._isLoading = false;
           cacheFileFolder.addEventListener("rise-storage-response", responseHandler);
           server.respondWith([200, newCacheHeader, ""]);
           cacheFileFolder._getFileFromCache();
+          server.respond();
         });
       });
     });

--- a/test/unit/rise-storage-unit.html
+++ b/test/unit/rise-storage-unit.html
@@ -135,10 +135,14 @@
         suite("bucket file", function() {
           var url = bucketImage.selfLink;
 
+          setup(function() {
+            fileBucket._reset();
+          });
+
           test("should return the correct URL for a specific file in a bucket", function(done) {
             listener = function(response) {
               responded = true;
-              assert.equal(response.detail.files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media");
               fileBucket.removeEventListener("rise-storage-response", listener);
             };
 
@@ -155,6 +159,8 @@
               responded = true;
             };
 
+            fileBucket._fileUrl = url + suffix;
+            fileBucket._handleStorageFile(bucketImage);
             fileBucket.addEventListener("rise-storage-response", listener);
             fileBucket._handleStorageFile(bucketImage);
             fileBucket.removeEventListener("rise-storage-response", listener);
@@ -166,10 +172,12 @@
           test("should return a new URL if the file has changed", function(done) {
             listener = function(response) {
               responded = true;
-              assert.equal(response.detail.files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media&cb=0");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media&cb=0");
               fileBucket.removeEventListener("rise-storage-response", listener);
             };
 
+            fileBucket._fileUrl = url + suffix;
+            fileBucket._handleStorageFile(bucketImage);
             bucketImage.etag = "new";
             fileBucket.addEventListener("rise-storage-response", listener);
             fileBucket._handleStorageFile(bucketImage);
@@ -185,10 +193,14 @@
         suite("folder file", function() {
           var url = folderImage.items[0].selfLink;
 
+          setup(function() {
+            fileFolder._reset();
+          });
+
           test("should return the correct URL for a specific file in a bucket", function(done) {
             listener = function(response) {
               responded = true;
-              assert.equal(response.detail.files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
               fileFolder.removeEventListener("rise-storage-response", listener);
             };
 
@@ -205,6 +217,8 @@
               responded = true;
             };
 
+            fileFolder._fileUrl = url + suffix;
+            fileFolder._handleStorageFile(folderImage);
             fileFolder.addEventListener("rise-storage-response", listener);
             fileFolder._handleStorageFile(folderImage);
             fileFolder.removeEventListener("rise-storage-response", listener);
@@ -216,10 +230,12 @@
           test("should return a new URL if the file has changed", function(done) {
             listener = function(response) {
               responded = true;
-              assert.equal(response.detail.files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&cb=0");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&cb=0");
               fileFolder.removeEventListener("rise-storage-response", listener);
             };
 
+            fileFolder._fileUrl = url + suffix;
+            fileFolder._handleStorageFile(folderImage);
             folderImage.items[0].etag = "new";
             fileFolder.addEventListener("rise-storage-response", listener);
             fileFolder._handleStorageFile(folderImage);
@@ -234,14 +250,30 @@
       });
 
       suite("_handleStorageFolder", function() {
+        var localImages;
+
+        setup(function() {
+          folder._reset();
+          localImages = JSON.parse(JSON.stringify(images));
+        });
+
+        teardown(function() {
+          images = localImages;
+        });
+
         test("should return the correct URLs for files in a folder", function(done) {
+          var files = [];
+
           listener = function(response) {
-            responded = true;
-            assert.equal(response.detail.files.length, 3);
-            assert.equal(response.detail.files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
-            assert.equal(response.detail.files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media");
-            assert.equal(response.detail.files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media");
-            folder.removeEventListener("rise-storage-response", listener);
+            files.push(response.detail);
+
+            if(files.length === 3) {
+              responded = true;
+              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
+              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media");
+              assert.equal(files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media");
+              folder.removeEventListener("rise-storage-response", listener);
+            }
           };
 
           folder.addEventListener("rise-storage-response", listener);
@@ -252,13 +284,18 @@
         });
 
         test("should return the same URLs if none of the files have changed", function(done) {
+          var files = [];
+
           listener = function(response) {
-            responded = true;
-            assert.equal(response.detail.files.length, 3);
-            assert.equal(response.detail.files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
-            assert.equal(response.detail.files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media");
-            assert.equal(response.detail.files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media");
-            folder.removeEventListener("rise-storage-response", listener);
+            files.push(response.detail);
+
+            if(files.length === 3) {
+              responded = true;
+              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
+              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media");
+              assert.equal(files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media");
+              folder.removeEventListener("rise-storage-response", listener);
+            }
           };
 
           folder.addEventListener("rise-storage-response", listener);
@@ -271,10 +308,12 @@
         test("should return new URL if a file has changed", function(done) {
           listener = function(response) {
             responded = true;
-            assert.equal(response.detail.files.length, 3);
-            assert.equal(response.detail.files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&cb=0");
+            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&cb=0");
+            assert.isTrue(response.detail.changed);
             folder.removeEventListener("rise-storage-response", listener);
           };
+
+          folder._handleStorageFolder(images);
 
           images.items[2].etag = "new";
           folder.addEventListener("rise-storage-response", listener);
@@ -287,10 +326,12 @@
         test("should return URL of a file that has been added to a folder", function(done) {
           listener = function(response) {
             responded = true;
-            assert.equal(response.detail.files.length, 4);
-            assert.equal(response.detail.files[3].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&cb=0");
+            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&cb=0");
+            assert.isTrue(response.detail.added);
             folder.removeEventListener("rise-storage-response", listener);
           };
+
+          folder._handleStorageFolder(images);
 
           images.items.push({
             "name": "images/golf.svg",
@@ -299,6 +340,7 @@
             "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg",
             "etag": "CPjC1qHc7MQCEAE="
           });
+
           folder.addEventListener("rise-storage-response", listener);
           folder._handleStorageFolder(images);
 
@@ -309,12 +351,11 @@
         test("should not return URL of a file that has been removed from a folder", function(done) {
           var listener = function(response) {
             responded = true;
-            assert.equal(response.detail.files.length, 3);
-            assert.equal(response.detail.files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
-            assert.equal(response.detail.files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&cb=0");
-            assert.equal(response.detail.files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media");
+            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media");
             folder.removeEventListener("rise-storage-response", listener);
           };
+
+          folder._handleStorageFolder(images);
 
           images.items.pop();
           folder.addEventListener("rise-storage-response", listener);
@@ -328,17 +369,33 @@
         folder._items = [];
 
         suite("Rise Cache", function() {
+          var localImages;
+
+          setup(function() {
+            cacheFolder._reset();
+            cacheFolder._isCacheRunning = true;
+            localImages = JSON.parse(JSON.stringify(images));
+          });
+
+          teardown(function() {
+            images = localImages;
+          });
+
           test("should return the correct URLs for files in a folder", function(done) {
+            var files = [];
+
             var listener = function(response) {
-              responded = true;
-              assert.equal(response.detail.files.length, 3);
-              assert.equal(response.detail.files[0].url, "http://localhost:9494/?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fhome.jpg%3Falt%3Dmedia");
-              assert.equal(response.detail.files[1].url, "http://localhost:9494/?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fcircle.png%3Falt%3Dmedia");
-              assert.equal(response.detail.files[2].url, "http://localhost:9494/?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fmy-image.bmp%3Falt%3Dmedia");
-              cacheFolder.removeEventListener("rise-storage-response", listener);
+              files.push(response.detail);
+
+              if(files.length === 3) {
+                responded = true;
+                assert.equal(files[0].url, "http://localhost:9494/?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fhome.jpg%3Falt%3Dmedia");
+                assert.equal(files[1].url, "http://localhost:9494/?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fcircle.png%3Falt%3Dmedia");
+                assert.equal(files[2].url, "http://localhost:9494/?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fmy-image.bmp%3Falt%3Dmedia");
+                cacheFolder.removeEventListener("rise-storage-response", listener);
+              }
             };
 
-            cacheFolder._isCacheRunning = true;
             cacheFolder.addEventListener("rise-storage-response", listener);
             cacheFolder._handleStorageFolder(images);
 
@@ -347,29 +404,26 @@
           });
 
           test("should return new URLs if none of the files have changed", function(done) {
-            var listener = function(response) {
-              responded = true;
-              assert.equal(response.detail.files.length, 3);
-              assert.equal(response.detail.files[0].url, "http://localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fhome.jpg%3Falt%3Dmedia");
-              assert.equal(response.detail.files[1].url, "http://localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fcircle.png%3Falt%3Dmedia");
-              assert.equal(response.detail.files[2].url, "http://localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fmy-image.bmp%3Falt%3Dmedia");
-              cacheFolder.removeEventListener("rise-storage-response", listener);
-            };
+            var listener = sinon.spy();
+
+            cacheFolder._handleStorageFolder(images);
 
             cacheFolder.addEventListener("rise-storage-response", listener);
             cacheFolder._handleStorageFolder(images);
 
-            assert.isTrue(responded);
+            assert.isTrue(listener.notCalled);
             done();
           });
 
           test("should return new URL if a file has changed", function(done) {
             var listener = function(response) {
               responded = true;
-              assert.equal(response.detail.files.length, 3);
-              assert.equal(response.detail.files[1].url, "http://localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fcircle.png%3Falt%3Dmedia");
+              assert.equal(response.detail.url, "http://localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fcircle.png%3Falt%3Dmedia");
+              assert.isTrue(response.detail.changed);
               cacheFolder.removeEventListener("rise-storage-response", listener);
             };
+
+            cacheFolder._handleStorageFolder(images);
 
             images.items[2].etag = "new";
             cacheFolder.addEventListener("rise-storage-response", listener);
@@ -382,10 +436,11 @@
           test("should return URL of a file that has been added to a folder", function(done) {
             var listener = function(response) {
               responded = true;
-              assert.equal(response.detail.files.length, 4);
-              assert.equal(response.detail.files[3].url, "http://localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia");
+              assert.equal(response.detail.url, "http://localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia");
               cacheFolder.removeEventListener("rise-storage-response", listener);
             };
+
+            cacheFolder._handleStorageFolder(images);
 
             images.items.push({
               "name": "images/golf.svg",
@@ -404,12 +459,11 @@
           test("should not return URL of a file that has been removed from a folder", function(done) {
             var listener = function(response) {
               responded = true;
-              assert.equal(response.detail.files.length, 3);
-              assert.equal(response.detail.files[0].url, "http://localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fhome.jpg%3Falt%3Dmedia");
-              assert.equal(response.detail.files[1].url, "http://localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fcircle.png%3Falt%3Dmedia");
-              assert.equal(response.detail.files[2].url, "http://localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fmy-image.bmp%3Falt%3Dmedia");
+              assert.equal(response.detail.url, "http://localhost:9494/?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fmy-image.bmp%3Falt%3Dmedia");
               cacheFolder.removeEventListener("rise-storage-response", listener);
             };
+
+            cacheFolder._handleStorageFolder(images);
 
             images.items.pop();
             cacheFolder.addEventListener("rise-storage-response", listener);
@@ -425,7 +479,10 @@
       });
 
       suite("_getFileFromCache", function() {
-        bucket._fileUrl = "http://url.to.my.file";
+        setup(function() {
+          bucket._reset();
+          bucket._fileUrl = "http://url.to.my.file";
+        });
 
         test("should correctly set the cache URL when loading", function() {
           bucket._isLoading = true;
@@ -771,48 +828,6 @@
               url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp"
             }]
           ));
-        });
-      });
-
-      suite("_prepareResponse", function() {
-        var response,
-          files =
-          [{
-            "sortBy": "images/home.jpg",
-            "url": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg"
-          },
-          {
-            "sortBy": "images/circle.png",
-            "url": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png"
-          },
-          {
-            "sortBy": "images/my-image.bmp",
-            "url": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp"
-          }];
-
-        test("should return an empty object when an empty array is passed in", function() {
-          response = JSON.stringify(folder._prepareResponse([]));
-
-          assert.equal(response, JSON.stringify( { "files": [] } ));
-        });
-
-        test("should return an object containing a sorted list of files", function() {
-          folder.sort = "name";
-          response = JSON.stringify(folder._prepareResponse(files));
-          result = {
-            "files": [
-              {
-                "url": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png"
-              },
-              {
-                "url": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg"
-              },
-              {
-                "url":"https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp"
-              }
-            ]};
-
-          assert.equal(response, JSON.stringify(result));
         });
       });
     });


### PR DESCRIPTION
This PR implements one of the proposed solutions for the delay issues when using cache on folders with many files. Instead of sending a single response with all the returned files, a message per file is sent on both regular and cached responses. Users of the component need to make changes to their implementations to consider this change. Test cases were updated to reflect the new methodology.

This PR also implements an alternative to solve the timing issues with test cases. Instead of using immediate mode, explicit respond() calls are made on the mocked server object. This way we make sure we use the correct mock data (looking at the logs several calls to the server can be seen, but they are made before the test cases run and do not affect them). 

The demo project and documentation were update accordingly.

@donnapep @stulees @tejohnso please review
