### PR TITLE
Provide environment selection attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The web component returns a JSON response for each file matching the provided cr
 | `sort`                 | `<string>` One of `name`, `date` or `random`.                                   | `''`             |
 | `sortDirection`        | `<string>` Either `asc` or `desc`.                                              | `''` (or `asc` if `sort` is `name` or `date`)|
 | `refresh`              | `<number>` The number of minutes before Storage will be checked for changes. The minimum refresh time is 5 minutes. | `0` (no refresh) |
+| `env`                  | `<string>` Either `prod` or `test`.                                             | `prod`           |
 
 ### Properties
 | Property         | Type                                              | Default |

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -92,6 +92,15 @@
       refresh: {
         type: Number,
         value: 0
+      },
+      /**
+       * The environment from which information should be retrieved.
+       *
+       * Possible values are "prod" or "test". In case the attribute is not provided, it defaults to "prod".
+       */
+      env: {
+        type: String,
+        value: "prod"
       }
     },
 
@@ -273,8 +282,10 @@
      * Sets the URL that is used for making requests to Storage.
      */
     _computeStorageUrl: function() {
-      //var baseUrl = "https://storage-dot-rvacore-test.appspot.com/_ah/api/storage/v0.01/files?companyId=" + encodeURIComponent(this.companyid),
-      var baseUrl = "https://storage-dot-rvaserver2.appspot.com/_ah/api/storage/v0.01/files?companyId=" + encodeURIComponent(this.companyid),
+      var productionUrl = "https://storage-dot-rvaserver2.appspot.com",
+        testingUrl = "https://storage-dot-rvacore-test.appspot.com",
+        serverUrl = (this.env !== "test" ? productionUrl : testingUrl),
+        baseUrl = serverUrl + "/_ah/api/storage/v0.01/files?companyId=" + encodeURIComponent(this.companyid),
         folder = encodeURIComponent(this.folder),
         filename = encodeURIComponent(this.filename),
         url = baseUrl;

--- a/test/unit/rise-storage-unit.html
+++ b/test/unit/rise-storage-unit.html
@@ -14,6 +14,7 @@
   <rise-storage id="noCompany"></rise-storage>
   <rise-storage id="bucket" companyId="abc123"></rise-storage>
   <rise-storage id="folder" companyId="abc123" folder="images"></rise-storage>
+  <rise-storage id="folder-testing" companyId="abc123" folder="images" env="test"></rise-storage>
   <rise-storage id="file-folder" companyId="abc123" folder="images" fileName="home.jpg"></rise-storage>
   <rise-storage id="file-bucket" companyId="abc123" fileName="home.jpg"></rise-storage>
   <rise-storage id="cache-folder" companyId="abc123" folder="images"></rise-storage>
@@ -31,6 +32,7 @@
         noCompany = document.querySelector("#noCompany"),
         bucket = document.querySelector("#bucket"),
         folder = document.querySelector("#folder"),
+        folderTesting = document.querySelector("#folder-testing"),
         fileFolder = document.querySelector("#file-folder"),
         cacheFolder = document.querySelector("#cache-folder"),
         cacheFile = document.querySelector("#cache-file"),
@@ -87,6 +89,11 @@
         test("should correctly set Storage request URL for a folder", function() {
           folder._computeStorageUrl();
           assert.equal(folder.$.storage.url, "https://storage-dot-rvaserver2.appspot.com/_ah/api/storage/v0.01/files?companyId=abc123&folder=images/");
+        });
+
+        test("should correctly set Storage request URL for a folder in the testing environment", function() {
+          folderTesting._computeStorageUrl();
+          assert.equal(folderTesting.$.storage.url, "https://storage-dot-rvacore-test.appspot.com/_ah/api/storage/v0.01/files?companyId=abc123&folder=images/");
         });
 
         test("should correctly set Storage request URL for a file in a folder", function() {


### PR DESCRIPTION
This PR adds an optional *env* attribute which can take either **prod** or **test** as its value, to choose the environment from which information should be retrieved. In case it's not provided, or if the value is something different to "test", it defaults to using production data (let me know if it should be the other way around).

@donnapep @stulees @tejohnso please review
