### PR TITLE
Change response type of requests to Rise Cache to text, to avoid having multiple copies of each file/blob in the temp folder (Chrome issue)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "authors": [
     "Donna Peplinskie <donna.peplinskie@risevision.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-component-rise-storage",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "The Rise Storage Web Component uses Google’s storage API to retrieve the URLs of all files in a particular folder, or the URL of a single file in a particular folder, from Rise Storage.",
   "scripts": {
     "test": "gulp test",

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -14,7 +14,7 @@
 
     <iron-ajax id="cache"
       url="{{_cacheUrl}}"
-      handle-as="blob"
+      handle-as="text"
       on-response="_handleCacheResponse"
       on-error="_handleCacheError"
       verbose="true">


### PR DESCRIPTION
Researching widget-image issue #17 (https://github.com/Rise-Vision/widget-image/issues/17), one workaround for the problem is using "text" instead of "blob" as the response type for requests to Rise Cache. Since Storage Component does not use the body of the response, changing this does not have impact.

@donnapep @stulees @tejohnso please review
