### PR TITLE
Add rise-storage-empty-folder event

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,12 @@ The web component returns a JSON response for each file matching the provided cr
 | `isCacheRunning` | `<boolean>` Whether or not Rise Cache is running. | `false` |
 
 ### Events
-| Event                   | Description                        |
-| ----------------------- | -----------------------------------|
-| `rise-storage-response` | Fired when a response is received. |
-| `rise-storage-error`    | Fired when an error is received.   |
+| Event                       | Description                                                 |
+| --------------------------- | ----------------------------------------------------------- |
+| `rise-storage-response`     | Fired when a response is received.                          |
+| `rise-storage-error`        | Fired when an error is received.                            |
+| `rise-storage-empty-folder` | Fired when the request is for a folder that is empty.       |
+| `rise-storage-no-folder`    | Fired when the request is for a folder that does not exist. |
 
 
 ### Methods

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.0.15",
+  "version": "1.1.0",
   "authors": [
     "Donna Peplinskie <donna.peplinskie@risevision.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-component-rise-storage",
-  "version": "1.0.15",
+  "version": "1.1.0",
   "description": "The Rise Storage Web Component uses Google’s storage API to retrieve the URLs of all files in a particular folder, or the URL of a single file in a particular folder, from Rise Storage.",
   "scripts": {
     "test": "gulp test",

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -155,11 +155,11 @@
     /**
      * Stores item details from the previous request.
      *
-     * @property _items
+     * @property _files
      * @type object
      * @default []
      */
-    _items: [],
+    _files: [],
 
     /**
      * The base URL for Rise Cache.
@@ -336,36 +336,39 @@
      */
     _processStorageResponse: function(e, resp) {
       if (resp && resp.response) {
-        if(resp.response.files) {
-          resp.response.items = resp.response.files;
-          delete resp.response.files;
+        if (this._isEmptyFolder(resp.response)) {
+          this.fire("rise-storage-empty-folder");
         }
-
-        if (this._isLoading) {
-          this._setIsFile(resp.response);
+        else if (this._noFolderExists(resp.response)) {
+          this.fire("rise-storage-no-folder");
         }
-
-        if (this._isFile) {
-          if (this._isLoading) {
-            this._setFileUrl(resp.response);
-          }
-
-          if (this._isCacheRunning) {
-            this._getFileFromCache();
-          }
-          // Rise Cache is not running.
-          else {
-            this._handleStorageFile(resp.response);
-          }
-        }
-        // Folder
         else {
-          if (this._isCacheRunning) {
-            this._getFilesFromCache(resp.response);
+          if (this._isLoading) {
+            this._setIsFile(resp.response);
           }
-          // Rise Cache is not running.
+
+          if (this._isFile) {
+            if (this._isLoading) {
+              this._setFileUrl(resp.response);
+            }
+
+            if (this._isCacheRunning) {
+              this._getFileFromCache();
+            }
+            // Rise Cache is not running.
+            else {
+              this._handleStorageFile(resp.response);
+            }
+          }
+          // Folder
           else {
-            this._handleStorageFolder(resp.response);
+            if (this._isCacheRunning) {
+              this._getFilesFromCache(resp.response);
+            }
+            // Rise Cache is not running.
+            else {
+              this._handleStorageFolder(resp.response);
+            }
           }
         }
       }
@@ -394,14 +397,14 @@
         etag = resp.etag;
       }
       // File in a folder.
-      else if ((resp.items !== undefined) && (resp.items.length > 0)) {
-        etag = resp.items[0].etag;
+      else if ((resp.files !== undefined) && (resp.files.length > 0)) {
+        etag = resp.files[0].etag;
       }
 
       file.url = this._fileUrl;
 
       if (this._isLoading) {
-        this._items.push({
+        this._files.push({
           "name": this._getFileNameFromUrl(file.url),
           "etag": etag
         });
@@ -412,13 +415,13 @@
       }
       else {
         // File hasn't changed.
-        if (this._items[0].etag === etag) {
+        if (this._files[0].etag === etag) {
           this._startTimer();
 
           return;
         }
         else {
-          this._items[0].etag = etag;
+          this._files[0].etag = etag;
           file.url += "&cb=" + new Date().getTime();
           file.changed = true;
         }
@@ -440,9 +443,9 @@
         suffix = "?alt=media",
         cb = "&cb=" + new Date().getTime();
 
-      if (resp.items) {
+      if (resp.files) {
         if (this.sort) {
-          resp.items.forEach(function(item) {
+          resp.files.forEach(function(item) {
             // Sorting
             if (self.sort) {
               if (self.sort === "name") {
@@ -454,15 +457,15 @@
             }
           });
 
-          resp.items = this._sortFiles(resp.items);
-          resp.items.forEach(function(item) {
+          resp.files = this._sortFiles(resp.files);
+          resp.files.forEach(function(item) {
             if (self.sort) {
               delete item.sortBy;
             }
           });
         }
 
-        resp.items.forEach(function(item) {
+        resp.files.forEach(function(item) {
           file = {};
 
           // Check that current item is not a folder.
@@ -484,7 +487,7 @@
                   file.url = item.selfLink;
                 }
 
-                self._items.push({
+                self._files.push({
                   "name": self._getFileNameFromUrl(file.url),
                   "etag": item.etag,
                   "url": file.url
@@ -504,13 +507,13 @@
                   file.url = item.selfLink;
                 }
 
-                previousItem = _.find(self._items, function(obj) {
+                previousItem = _.find(self._files, function(obj) {
                   return obj.name === item.name;
                 });
 
                 // New file
                 if (previousItem === undefined) {
-                  self._items.push({
+                  self._files.push({
                     "name": self._getFileNameFromUrl(file.url),
                     "etag": item.etag,
                     "url": file.url
@@ -545,7 +548,7 @@
                 delete file.sortBy;
               }
 
-              if(!file.unchanged) {
+              if (!file.unchanged) {
                 file.name = self._getFileNameFromUrl(file.url);
 
                 self.fire("rise-storage-response", file);
@@ -554,7 +557,7 @@
           }
         });
 
-        this._processRemovedFiles(resp.items);
+        this._processRemovedFiles(resp.files);
         this._isLoading = false;
         this._startTimer();
       }
@@ -584,20 +587,20 @@
     _getFilesFromCache: function(resp) {
       var self = this;
 
-      if (resp.items) {
+      if (resp.files) {
         this._numFiles = 0;
         this._isChanged = false;
         this._totalFilesBefore = this._totalFiles;
 
         // Only count actual files (ignore folders)
-        this._totalFiles = resp.items.filter(function(item) {
+        this._totalFiles = resp.files.filter(function(item) {
           return item.name && (item.name.slice(-1) !== "/");
         }).length;
 
         // Remove no longer existing files
-        this._processRemovedFiles(resp.items);
+        this._processRemovedFiles(resp.files);
 
-        resp.items.forEach(function(item) {
+        resp.files.forEach(function(item) {
           // Check that current item is not a folder.
           if (item.name && (item.name.slice(-1) !== "/")) {
             if (!self._filterFiles(item.contentType)) {
@@ -638,7 +641,7 @@
 
         if (this._isLoading) {
           // Save Last Modified so it can be compared in subsequent requests.
-          this._items.push({
+          this._files.push({
             "name": this._getFileNameFromUrl(file.url),
             "lastModified": lastModified
           });
@@ -653,14 +656,14 @@
         }
         else {
           // Rise Cache file hasn't changed.
-          if (this._items[0].lastModified === lastModified) {
+          if (this._files[0].lastModified === lastModified) {
             file.unchanged = true;
             this._startTimer();
 
             return;
           }
           else {
-            this._items[0].lastModified = lastModified;
+            this._files[0].lastModified = lastModified;
             this.changed = true;
             file.changed = true;
           }
@@ -700,7 +703,7 @@
 
         if (this._isLoading) {
           // Save file details so they can be compared in subsequent requests.
-          this._items.push({
+          this._files.push({
             "name": this._getFileNameFromUrl(file.url),
             "lastModified": lastModified,
             "fullUrl": file.url,
@@ -714,13 +717,13 @@
           }
         }
         else {
-          previousItem = _.find(this._items, function(obj) {
+          previousItem = _.find(this._files, function(obj) {
             return obj.url === url;
           });
 
           // New file
           if (previousItem === undefined) {
-            this._items.push({
+            this._files.push({
               "name": this._getFileNameFromUrl(file.url),
               "lastModified": lastModified,
               "fullUrl": file.url,
@@ -809,11 +812,11 @@
         });
       }
 
-      for(var i = this._items.length - 1; i >= 0; i--) {
-        var file = this._items[i];
+      for(var i = this._files.length - 1; i >= 0; i--) {
+        var file = this._files[i];
 
         if(!fileExists(file)) {
-          this._items.splice(i, 1);
+          this._files.splice(i, 1);
           file.deleted = true;
 
           this.fire("rise-storage-response", file);
@@ -865,6 +868,21 @@
     },
 
     /**
+     * Checks if the request is for a folder that does not exist.
+     */
+    _noFolderExists: function(resp) {
+      return resp.files === undefined;
+    },
+
+    /**
+     * Checks if the request is for an empty folder.
+     */
+    _isEmptyFolder: function(resp) {
+      return (resp.files !== undefined) && (resp.files.length === 1) &&
+        (resp.files[0].name.slice(-1) === "/");
+    },
+
+    /**
      * Checks if the request is for a file.
      */
     _setIsFile: function(response) {
@@ -873,8 +891,8 @@
         this._isFile = true;
       }
       // File in a folder.
-      else if ((response.items !== undefined) && (response.items.length > 0)) {
-        if (response.items.length === 1) {
+      else if ((response.files !== undefined) && (response.files.length > 0)) {
+        if (response.files.length === 1) {
           this._isFile = true;
         }
         else {
@@ -899,8 +917,8 @@
         url = response.selfLink;
       }
       // File in a folder.
-      else if (response.items) {
-        url = response.items[0].selfLink;
+      else if (response.files) {
+        url = response.files[0].selfLink;
       }
 
       if (this._isCacheRunning) {
@@ -1111,7 +1129,7 @@
       this._isFile = true;
       this._cacheUrl = "";
       this._fileUrl = "";
-      this._items = [];
+      this._files = [];
       this._isCacheRunning = false;
       this._pingReceived = false;
       this._numFiles = 0;

--- a/test/integration/rise-cache.html
+++ b/test/integration/rise-cache.html
@@ -49,14 +49,13 @@
           cacheFile._fileUrl = "https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fhome.jpg";
         });
 
-        teardown(function() {
-          cacheFile.removeEventListener("rise-storage-response", responseHandler);
-        });
-
         test("should return the correct URL for a specific file in a bucket", function(done) {
           responseHandler = function(response) {
             assert.equal(response.detail.name, "home.jpg");
             assert.equal(response.detail.url, "http://localhost:9494/?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fhome.jpg");
+
+            cacheFile.removeEventListener("rise-storage-response", responseHandler);
+
             done();
           };
 
@@ -82,10 +81,13 @@
           responseHandler = function(response) {
             assert.equal(response.detail.name, "home.jpg");
             assert.equal(response.detail.url, "http://localhost:9494/cb=0?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fhome.jpg");
+
+            cacheFile.removeEventListener("rise-storage-response", responseHandler);
+
             done();
           };
 
-          cacheFile._items.push({
+          cacheFile._files.push({
             "name": "home.jpg", "lastModified": ""
           });
 
@@ -105,14 +107,13 @@
           cacheFileFolder._fileUrl = "https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fimages%252Fhome.jpg";
         });
 
-        teardown(function() {
-          cacheFileFolder.removeEventListener("rise-storage-response", responseHandler);
-        });
-
         test("should return the correct URL for a specific file in a folder", function(done) {
           responseHandler = function(response) {
             assert.equal(response.detail.name, "images/home.jpg");
             assert.equal(response.detail.url, "http://localhost:9494/?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fimages%252Fhome.jpg");
+
+            cacheFileFolder.removeEventListener("rise-storage-response", responseHandler);
+
             done();
           };
 
@@ -138,10 +139,13 @@
           responseHandler = function(response) {
             assert.equal(response.detail.name, "images/home.jpg");
             assert.equal(response.detail.url, "http://localhost:9494/cb=0?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fimages%252Fhome.jpg");
+
+            cacheFileFolder.removeEventListener("rise-storage-response", responseHandler);
+
             done();
           };
 
-          cacheFileFolder._items.push({
+          cacheFileFolder._files.push({
             "name": "risemedialibrary-abc123/images/home.jpg", "lastModified": ""
           });
 

--- a/test/integration/rise-storage.html
+++ b/test/integration/rise-storage.html
@@ -53,7 +53,7 @@
         });
 
         teardown(function() {
-          bucketImage.etag = "COjLvarr/cQCEAE=";
+          bucketImage.files[0].etag = "COjLvarr/cQCEAE=";
           file.removeEventListener("rise-storage-response", responseHandler);
         });
 
@@ -90,7 +90,7 @@
           };
 
           var localBucketImage = JSON.parse(JSON.stringify(bucketImage));
-          localBucketImage.etag = "new";
+          localBucketImage.files[0].etag = "new";
 
           file.addEventListener("rise-storage-response", responseHandler);
           server.respondWith([200, header, JSON.stringify(localBucketImage)]);
@@ -161,7 +161,7 @@
           fileFolder.go();
           server.respond();
 
-          folderImage.items[0].etag = "new";
+          folderImage.files[0].etag = "new";
 
           server.respondWith([200, header, JSON.stringify(folderImage)]);
           fileFolder.go();
@@ -238,7 +238,7 @@
           folder.go();
           server.respond();
 
-          images.items[2].etag = "new";
+          images.files[2].etag = "new";
 
           server.respondWith([200, header, JSON.stringify(images)]);
           folder.go();
@@ -263,7 +263,7 @@
           folder.go();
           server.respond();
 
-          images.items.push({
+          images.files.push({
             "name": "images/golf.svg",
             "contentType": "image/svg+xml",
             "updated": "2015-01-30T08:19:09.263Z",
@@ -304,11 +304,157 @@
           folder.go();
           server.respond();
 
-          images.items.pop();
+          images.files.pop();
 
           server.respondWith([200, header, JSON.stringify(images)]);
           folder.go();
           server.respond();
+        });
+      });
+
+      suite("rise-storage-empty-folder", function() {
+        setup(function() {
+          folder._reset();
+          folder._isCacheRunning = false;
+          folder._pingReceived = true;
+        });
+
+        teardown(function() {
+          folder.removeEventListener("rise-storage-empty-folder", responseHandler);
+        });
+
+        test("should fire rise-storage-empty-folder if a folder is empty", function(done) {
+          responseHandler = function(response) {
+            assert.isObject(response.detail, "response.detail is an object");
+            assert.deepEqual(response.detail, {}, "response.detail is an empty object");
+
+            done();
+          };
+
+          folder.addEventListener("rise-storage-empty-folder", responseHandler);
+          server.respondWith([200, header, JSON.stringify(emptyFolder)]);
+          folder.go();
+          server.respond();
+        });
+
+        test("should not fire rise-storage-empty-folder if a folder does not exist", function(done) {
+          responseHandler = sinon.spy();
+
+          folder.addEventListener("rise-storage-empty-folder", responseHandler);
+          server.respondWith([200, header, JSON.stringify(noFolder)]);
+          folder.go();
+          server.respond();
+
+          assert(responseHandler.notCalled);
+          done();
+        });
+
+        test("should not fire rise-storage-empty-folder if a folder does exist", function(done) {
+          responseHandler = sinon.spy();
+
+          folder.addEventListener("rise-storage-empty-folder", responseHandler);
+          server.respondWith([200, header, JSON.stringify(images)]);
+          folder.go();
+          server.respond();
+
+          assert(responseHandler.notCalled);
+          done();
+        });
+
+        test("should not fire rise-storage-empty-folder if the request is for a bucket file", function(done) {
+          responseHandler = sinon.spy();
+
+          file.addEventListener("rise-storage-empty-folder", responseHandler);
+          server.respondWith([200, header, JSON.stringify(bucketImage)]);
+          file.go();
+          server.respond();
+
+          assert(responseHandler.notCalled);
+          done();
+        });
+
+        test("should not fire rise-storage-empty-folder if the request is for a file in a folder", function(done) {
+          responseHandler = sinon.spy();
+
+          fileFolder.addEventListener("rise-storage-empty-folder", responseHandler);
+          server.respondWith([200, header, JSON.stringify(folderImage)]);
+          fileFolder.go();
+          server.respond();
+
+          assert(responseHandler.notCalled);
+          done();
+        });
+      });
+
+      suite("rise-storage-no-folder", function() {
+        setup(function() {
+          folder._reset();
+          folder._isCacheRunning = false;
+          folder._pingReceived = true;
+        });
+
+        test("should fire rise-storage-no-folder if a folder does not exist", function(done) {
+          responseHandler = function(response) {
+            assert.isObject(response.detail, "response.detail is an object");
+            assert.deepEqual(response.detail, {}, "response.detail is an empty object");
+
+            folder.removeEventListener("rise-storage-no-folder", responseHandler);
+
+            done();
+          };
+
+          folder.addEventListener("rise-storage-no-folder", responseHandler);
+          server.respondWith([200, header, JSON.stringify(noFolder)]);
+          folder.go();
+          server.respond();
+        });
+
+        test("should not fire rise-storage-no-folder if a folder does exist", function(done) {
+          responseHandler = sinon.spy();
+
+          folder.addEventListener("rise-storage-no-folder", responseHandler);
+          server.respondWith([200, header, JSON.stringify(images)]);
+          folder.go();
+          server.respond();
+
+          assert(responseHandler.notCalled);
+          done();
+        });
+
+        test("should not fire rise-storage-no-folder if a folder is empty", function(done) {
+          responseHandler = sinon.spy();
+
+          folder.addEventListener("rise-storage-no-folder", responseHandler);
+          server.respondWith([200, header, JSON.stringify(emptyFolder)]);
+          folder.go();
+          server.respond();
+
+          assert(responseHandler.notCalled);
+          done();
+        });
+
+        test("should not fire rise-storage-no-folder if the request is for a bucket file", function(done) {
+          responseHandler = sinon.spy();
+
+          file.addEventListener("rise-storage-no-folder", responseHandler);
+          server.respondWith([200, header, JSON.stringify(bucketImage)]);
+          file.go();
+          server.respond();
+
+          assert(responseHandler.notCalled);
+          done();
+        });
+
+        test("should not fire rise-storage-no-folder if the request is for a file in a folder", function(done) {
+          responseHandler = sinon.spy();
+
+          fileFolder.addEventListener("rise-storage-no-folder", responseHandler);
+          server.respondWith([200, header, JSON.stringify(folderImage)]);
+          fileFolder.go();
+          server.respond();
+
+          assert(responseHandler.notCalled);
+          done();
         });
       });
 

--- a/test/js/rise-storage-data.js
+++ b/test/js/rise-storage-data.js
@@ -1,6 +1,6 @@
 var header = { "Content-Type": "text/json" },
   images = {
-    "items": [{
+    "files": [{
       "name": "images/",
       "contentType": "text/plain",
       "updated": "2015-02-04T17:44:00.549Z",
@@ -30,7 +30,7 @@ var header = { "Content-Type": "text/json" },
     }]
   },
   mixedMedia = {
-    "items": [{
+    "files": [{
       "name": "images/",
       "contentType": "text/plain",
       "updated": "2015-02-04T17:44:00.549Z",
@@ -95,7 +95,7 @@ var header = { "Content-Type": "text/json" },
     }]
   },
   folderImage = {
-    "items": [{
+    "files": [{
       "name": "images/home.jpg",
       "contentType": "image/jpeg",
       "updated": "2015-02-04T17:45:25.945Z",
@@ -104,14 +104,25 @@ var header = { "Content-Type": "text/json" },
     }]
   },
   bucketImage = {
-    "name": "home.jpg",
-    "contentType": "image/jpeg",
-    "updated": "2015-02-04T17:45:25.945Z",
-    "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg",
-    "etag": "COjLvarr/cQCEAE="
+    "result": true,
+    "code": 200,
+    "files": [{
+      "contentType": "image/jpeg",
+      "etag": "COjLvarr/cQCEAE=",
+      "name": "home.jpg",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg",
+      "updated": {
+        "value": "1431455000152",
+        "dateOnly": false,
+        "timeZoneShift": 0
+      },
+    }],
+    "bucketExists": true,
+    "kind": "storage#filesItem",
+    "etag": "\"-xn2BkoYzbrr0EhwVLI1-3fTi7c/1Ev8FzsCppGm6uDNrJyFySGIKrI\""
   },
   imagesAndFolders = {
-    "items": [{
+    "files": [{
       "name": "images/",
       "contentType": "text/plain",
       "updated": "2015-02-04T17:44:00.549Z",
@@ -146,5 +157,30 @@ var header = { "Content-Type": "text/json" },
       "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fsubfolder2%2F",
       "etag": "CIjxrtzryMMCEAE="
     }]
+  },
+  noFolder = {
+    "result": true,
+    "code": 200,
+    "bucketExists": true,
+    "kind": "storage#filesItem",
+    "etag": "\"-xn2BkoYzbrr0EhwVLI1-3fTi7c/nRo7jDSle-_CoystXctokYbq8Pc\""
+  },
+  emptyFolder = {
+    "result": true,
+    "code": 200,
+    "files": [{
+      "contentType": "text/plain",
+      "etag": "CODYtNjV+ccCEAE=",
+      "name": "Donna/",
+      "selfLink": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2F",
+      "updated": {
+        "value": "1442341739897",
+        "dateOnly": false,
+        "timeZoneShift": 0
+      }
+    }],
+    "bucketExists": true,
+    "kind": "storage#filesItem",
+    "etag": "\"-xn2BkoYzbrr0EhwVLI1-3fTi7c/1Ev8FzsCppGm6uDNrJyFySGIKrI\""
   },
   xhr, requests;

--- a/test/unit/rise-cache.html
+++ b/test/unit/rise-cache.html
@@ -105,7 +105,7 @@
 
           cacheFolder._handleStorageFolder(images);
 
-          images.items[2].etag = "new";
+          images.files[2].etag = "new";
           cacheFolder.addEventListener("rise-storage-response", listener);
           cacheFolder._handleStorageFolder(images);
 
@@ -123,7 +123,7 @@
 
           cacheFolder._handleStorageFolder(images);
 
-          images.items.push({
+          images.files.push({
             "name": "images/golf.svg",
             "contentType": "image/svg+xml",
             "updated": "2015-01-30T08:19:09.263Z",
@@ -147,16 +147,16 @@
 
           cacheFolder._handleStorageFolder(images);
 
-          images.items.pop();
+          images.files.pop();
           cacheFolder.addEventListener("rise-storage-response", listener);
           cacheFolder._handleStorageFolder(images);
 
           assert.isTrue(responded);
-          images.items[2].etag = "CMiEudSn2MMCEAs=";
+          images.files[2].etag = "CMiEudSn2MMCEAs=";
           done();
         });
 
-        cacheFolder._items = [];
+        cacheFolder._files = [];
       });
 
 

--- a/test/unit/rise-storage.html
+++ b/test/unit/rise-storage.html
@@ -131,7 +131,7 @@
 
       suite("_handleStorageFile", function() {
         suite("bucket file", function() {
-          var url = bucketImage.selfLink;
+          var url = bucketImage.files[0].selfLink;
 
           setup(function() {
             fileBucket._reset();
@@ -178,7 +178,7 @@
 
             fileBucket._fileUrl = url + suffix;
             fileBucket._handleStorageFile(bucketImage);
-            bucketImage.etag = "new";
+            bucketImage.files[0].etag = "new";
             fileBucket.addEventListener("rise-storage-response", listener);
             fileBucket._handleStorageFile(bucketImage);
 
@@ -187,11 +187,11 @@
             done();
           });
 
-          fileBucket._items = [];
+          fileBucket._files = [];
         });
 
         suite("folder file", function() {
-          var url = folderImage.items[0].selfLink;
+          var url = folderImage.files[0].selfLink;
 
           setup(function() {
             fileFolder._reset();
@@ -238,16 +238,16 @@
 
             fileFolder._fileUrl = url + suffix;
             fileFolder._handleStorageFile(folderImage);
-            folderImage.items[0].etag = "new";
+            folderImage.files[0].etag = "new";
             fileFolder.addEventListener("rise-storage-response", listener);
             fileFolder._handleStorageFile(folderImage);
 
             assert.isTrue(responded);
-            folderImage.items[0].etag = "COjLvarr/cQCEAE=";
+            folderImage.files[0].etag = "COjLvarr/cQCEAE=";
             done();
           });
 
-          fileFolder._items = [];
+          fileFolder._files = [];
         });
       });
 
@@ -324,7 +324,7 @@
 
           folder._handleStorageFolder(images);
 
-          images.items[2].etag = "new";
+          images.files[2].etag = "new";
           folder.addEventListener("rise-storage-response", listener);
           folder._handleStorageFolder(images);
 
@@ -343,7 +343,7 @@
 
           folder._handleStorageFolder(images);
 
-          images.items.push({
+          images.files.push({
             "name": "images/golf.svg",
             "contentType": "image/svg+xml",
             "updated": "2015-01-30T08:19:09.263Z",
@@ -368,13 +368,57 @@
 
           folder._handleStorageFolder(images);
 
-          images.items.pop();
+          images.files.pop();
           folder.addEventListener("rise-storage-response", listener);
           folder._handleStorageFolder(images);
 
           assert.isTrue(responded);
-          images.items[2].etag = "CMiEudSn2MMCEAs=";
+          images.files[2].etag = "CMiEudSn2MMCEAs=";
           done();
+        });
+      });
+
+      suite("_isEmptyFolder", function() {
+        test("should return false for a file in the root of the bucket", function() {
+          assert.equal(fileBucket._isEmptyFolder(bucketImage), false);
+        });
+
+        test("should return false for a file in a folder", function() {
+          assert.equal(fileFolder._isEmptyFolder(folderImage), false);
+        });
+
+        test("should return false for a folder that has files", function() {
+          assert.equal(folder._isEmptyFolder(images), false);
+        });
+
+        test("should return false if the folder does not exist", function() {
+          assert.equal(folder._isEmptyFolder(noFolder), false);
+        });
+
+        test("should return true for an empty folder", function() {
+          assert.equal(folder._isEmptyFolder(emptyFolder), true);
+        });
+      });
+
+      suite("_noFolderExists", function() {
+        test("should return false for a file in the root of the bucket", function() {
+          assert.equal(fileBucket._noFolderExists(bucketImage), false);
+        });
+
+        test("should return false for a file in a folder", function() {
+          assert.equal(fileFolder._noFolderExists(folderImage), false);
+        });
+
+        test("should return false for a folder that has files", function() {
+          assert.equal(folder._noFolderExists(images), false);
+        });
+
+        test("should return false for an empty folder", function() {
+          assert.equal(folder._noFolderExists(emptyFolder), false);
+        });
+
+        test("should return true if the folder does not exist", function() {
+          assert.equal(folder._noFolderExists(noFolder), true);
         });
       });
 


### PR DESCRIPTION
* Storage response returns `files` property instead of `items`. Changed all references.
* Return `rise-storage-empty-folder` if folder is empty.
* Return `rise-storage-no-folder` if folder does not exist.