### PR TITLE
Add rise-storage-no-file event

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ The web component returns a JSON response for each file matching the provided cr
 | `rise-storage-error`        | Fired when an error is received.                            |
 | `rise-storage-empty-folder` | Fired when the request is for a folder that is empty.       |
 | `rise-storage-no-folder`    | Fired when the request is for a folder that does not exist. |
+| `rise-storage-no-file`      | Fired when the request is for a specified file that does not exist. |
 
 
 ### Methods

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "authors": [
     "Donna Peplinskie <donna.peplinskie@risevision.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-component-rise-storage",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "The Rise Storage Web Component uses Google’s storage API to retrieve the URLs of all files in a particular folder, or the URL of a single file in a particular folder, from Rise Storage.",
   "scripts": {
     "test": "gulp test",

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -340,7 +340,12 @@
           this.fire("rise-storage-empty-folder");
         }
         else if (this._noFolderExists(resp.response)) {
-          this.fire("rise-storage-no-folder");
+          if (this.filename) {
+            this.fire("rise-storage-no-file");
+          }
+          else {
+            this.fire("rise-storage-no-folder");
+          }
         }
         else {
           if (this._isLoading) {

--- a/test/integration/rise-storage.html
+++ b/test/integration/rise-storage.html
@@ -458,6 +458,83 @@
         });
       });
 
+      suite("rise-storage-no-file", function() {
+        setup(function() {
+          file._reset();
+          file._isCacheRunning = false;
+          file._pingReceived = true;
+        });
+
+        test("should fire rise-storage-no-file if a bucket file does not exist", function(done) {
+          responseHandler = function(response) {
+            assert.isObject(response.detail, "response.detail is an object");
+            assert.deepEqual(response.detail, {}, "response.detail is an empty object");
+
+            file.removeEventListener("rise-storage-no-file", responseHandler);
+
+            done();
+          };
+
+          file.addEventListener("rise-storage-no-file", responseHandler);
+          server.respondWith([200, header, JSON.stringify(noFolder)]);
+          file.go();
+          server.respond();
+        });
+
+        test("should fire rise-storage-no-file if a folder file does not exist", function(done) {
+          responseHandler = function(response) {
+            assert.isObject(response.detail, "response.detail is an object");
+            assert.deepEqual(response.detail, {}, "response.detail is an empty object");
+
+            fileFolder.removeEventListener("rise-storage-no-file", responseHandler);
+
+            done();
+          };
+
+          fileFolder.addEventListener("rise-storage-no-file", responseHandler);
+          server.respondWith([200, header, JSON.stringify(noFolder)]);
+          fileFolder.go();
+          server.respond();
+        });
+
+        test("should not fire rise-storage-no-file if a bucket file does exist", function(done) {
+          responseHandler = sinon.spy();
+
+          file.addEventListener("rise-storage-no-file", responseHandler);
+          server.respondWith([200, header, JSON.stringify(bucketImage)]);
+          file.go();
+          server.respond();
+
+          assert(responseHandler.notCalled);
+          done();
+        });
+
+        test("should not fire rise-storage-no-file if a folder file does exist", function(done) {
+          responseHandler = sinon.spy();
+
+          fileFolder.addEventListener("rise-storage-no-file", responseHandler);
+          server.respondWith([200, header, JSON.stringify(folderImage)]);
+          fileFolder.go();
+          server.respond();
+
+          assert(responseHandler.notCalled);
+          done();
+        });
+
+        test("should not fire rise-storage-no-file if the request is for a folder", function(done) {
+          responseHandler = sinon.spy();
+
+          folder.addEventListener("rise-storage-no-file", responseHandler);
+          server.respondWith([200, header, JSON.stringify(images)]);
+          folder.go();
+          server.respond();
+
+          assert(responseHandler.notCalled);
+          done();
+        });
+
+      });
+
       suite("filtering", function() {
         setup(function() {
           fileType._reset();


### PR DESCRIPTION
- Return `rise-storage-no-file` if a specified file does not exist
- Applicable test coverage
- Documented in README
- Version bump