### PR TITLE
Changed rise cache request to be use HEAD as method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 bower_components/
+.idea
+web-component-rise-storage.iml

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "authors": [
     "Donna Peplinskie <donna.peplinskie@risevision.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-component-rise-storage",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "The Rise Storage Web Component uses Google’s storage API to retrieve the URLs of all files in a particular folder, or the URL of a single file in a particular folder, from Rise Storage.",
   "scripts": {
     "test": "gulp test",

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -13,6 +13,7 @@
     </iron-ajax>
 
     <iron-ajax id="cache"
+      method="{{_cacheRequestMethod}}"
       url="{{_cacheUrl}}"
       handle-as="text"
       on-response="_handleCacheResponse"
@@ -142,6 +143,24 @@
      * @default ""
      */
     _cacheUrl: "",
+
+    /**
+     * The method for the Cache request.
+     *
+     * @property _cacheRequestMethod
+     * @type string
+     * @default "HEAD"
+     */
+    _cacheRequestMethod: "HEAD",
+
+    /**
+     * The flag for making a get request if it wasn't done yet.
+     *
+     * @property _hasAttemptedGetRequest
+     * @type string
+     * @default false
+     */
+    _hasAttemptedGetRequest: false,
 
     /**
      * The URL target of the Cache request.
@@ -800,8 +819,15 @@
      * Fires when an error is received from the Rise Cache request.
      */
     _handleCacheError: function(e, resp) {
-      this._startTimer();
-      this.fire("rise-storage-error", resp);
+      if ( !this._hasAttemptedGetRequest ) {
+        this._cacheRequestMethod = "GET";
+        this.$.cache.generateRequest();
+        this._hasAttemptedGetRequest = true;
+      }
+      else {
+        this._startTimer();
+        this.fire("rise-storage-error", resp);
+      }
     },
 
     /**
@@ -1177,6 +1203,8 @@
       this._totalFiles = 0;
       this._totalFilesBefore = 0;
       this._isChanged = false;
+      this._cacheRequestMethod = "HEAD";
+      this._hasAttemptedGetRequest = false;
     }
   });
 </script>

--- a/test/unit/rise-cache.html
+++ b/test/unit/rise-cache.html
@@ -200,6 +200,26 @@
       });
 
       suite("_handleCacheError", function() {
+
+        test("should retry Rise Cache request with GET method if it fails the first time", function(done) {
+          var resp = {
+              "xhr": {
+                "status": 404,
+                "statusText": "An error occurred"
+              }
+            },
+            listener = function(response) {
+              responded = true;
+              cacheFile.removeEventListener("rise-storage-error", listener);
+            };
+          cacheFile._hasAttemptedGetRequest = false;
+          cacheFile.addEventListener("rise-storage-error", listener);
+          cacheFile._handleCacheError({}, resp);
+          assert.isFalse(responded);
+          assert.equal(cacheFile._cacheRequestMethod, "GET");
+          done();
+        });
+
         test("should fire rise-storage-error if there is a problem with the Rise Cache request", function(done) {
           var resp = {
             "xhr": {
@@ -211,7 +231,7 @@
             responded = true;
             cacheFile.removeEventListener("rise-storage-error", listener);
           };
-
+          cacheFile._hasAttemptedGetRequest = true;
           cacheFile.addEventListener("rise-storage-error", listener);
           cacheFile._handleCacheError({}, resp);
           assert.isTrue(responded);


### PR DESCRIPTION
It will try the HEAD request first. If it fails, it will try then the get request. 

@donnapep please review.

This presentation is using it. http://rva.risevision.com/#/PRESENTATION_MANAGE/id=243b57d7-22c4-4793-87f7-edb918281023?cid=30007b45-3df0-4c7b-9f7f-7d8ce6443013