### PR TITLE
Removed get fallback for CAPs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "authors": [
     "Donna Peplinskie <donna.peplinskie@risevision.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-component-rise-storage",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "The Rise Storage Web Component uses Google’s storage API to retrieve the URLs of all files in a particular folder, or the URL of a single file in a particular folder, from Rise Storage.",
   "scripts": {
     "test": "gulp test",

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -13,7 +13,7 @@
     </iron-ajax>
 
     <iron-ajax id="cache"
-      method="{{_cacheRequestMethod}}"
+      method="HEAD"
       url="{{_cacheUrl}}"
       handle-as="text"
       on-response="_handleCacheResponse"
@@ -143,24 +143,6 @@
      * @default ""
      */
     _cacheUrl: "",
-
-    /**
-     * The method for the Cache request.
-     *
-     * @property _cacheRequestMethod
-     * @type string
-     * @default "HEAD"
-     */
-    _cacheRequestMethod: "HEAD",
-
-    /**
-     * The flag for making a get request if it wasn't done yet.
-     *
-     * @property _hasAttemptedGetRequest
-     * @type string
-     * @default false
-     */
-    _hasAttemptedGetRequest: false,
 
     /**
      * The URL target of the Cache request.
@@ -615,9 +597,6 @@
      */
     _getFileFromCache: function() {
 
-      this._cacheRequestMethod = "HEAD";
-      this._hasAttemptedGetRequest = false;
-
       if (this._isLoading) {
         this._cacheUrl = this._baseCacheUrl + "?url=" + this._fileUrl;
       }
@@ -634,9 +613,6 @@
      * Make requests to Rise Cache to retrieve all files in a folder.
      */
     _getFilesFromCache: function(resp) {
-
-      this._cacheRequestMethod = "HEAD";
-      this._hasAttemptedGetRequest = false;
 
       var self = this;
 
@@ -827,15 +803,8 @@
      * Fires when an error is received from the Rise Cache request.
      */
     _handleCacheError: function(e, resp) {
-      if ( !this._hasAttemptedGetRequest ) {
-        this._cacheRequestMethod = "GET";
-        this.$.cache.generateRequest();
-        this._hasAttemptedGetRequest = true;
-      }
-      else {
-        this._startTimer();
-        this.fire("rise-storage-error", resp);
-      }
+      this._startTimer();
+      this.fire("rise-storage-error", resp);
     },
 
     /**
@@ -1211,8 +1180,6 @@
       this._totalFiles = 0;
       this._totalFilesBefore = 0;
       this._isChanged = false;
-      this._cacheRequestMethod = "HEAD";
-      this._hasAttemptedGetRequest = false;
     }
   });
 </script>

--- a/test/unit/rise-cache.html
+++ b/test/unit/rise-cache.html
@@ -166,12 +166,6 @@
           cacheFile._fileUrl = "http://url.to.my.file";
         });
 
-        test("should correctly set the cache request method to HEAD", function() {
-          cacheFile._getFileFromCache();
-          assert.equal(cacheFile._cacheRequestMethod, "HEAD");
-          assert.equal(cacheFile._hasAttemptedGetRequest, false);
-        });
-
         test("should correctly set the cache URL when loading", function() {
           cacheFile._isLoading = true;
           cacheFile._getFileFromCache();
@@ -186,12 +180,6 @@
       });
 
       suite("_getFilesFromCache", function() {
-
-        test("should correctly set the cache request method to HEAD", function() {
-          cacheFolder._getFilesFromCache(images);
-          assert.equal(cacheFolder._cacheRequestMethod, "HEAD");
-          assert.equal(cacheFolder._hasAttemptedGetRequest, false);
-        });
 
         test("should correctly set number of total files in a folder", function() {
           cacheFolder._getFilesFromCache(images);
@@ -214,25 +202,6 @@
 
       suite("_handleCacheError", function() {
 
-        test("should retry Rise Cache request with GET method if it fails the first time", function(done) {
-          var resp = {
-              "xhr": {
-                "status": 404,
-                "statusText": "An error occurred"
-              }
-            },
-            listener = function(response) {
-              responded = true;
-              cacheFile.removeEventListener("rise-storage-error", listener);
-            };
-          cacheFile._hasAttemptedGetRequest = false;
-          cacheFile.addEventListener("rise-storage-error", listener);
-          cacheFile._handleCacheError({}, resp);
-          assert.isFalse(responded);
-          assert.equal(cacheFile._cacheRequestMethod, "GET");
-          done();
-        });
-
         test("should fire rise-storage-error if there is a problem with the Rise Cache request", function(done) {
           var resp = {
             "xhr": {
@@ -244,7 +213,6 @@
             responded = true;
             cacheFile.removeEventListener("rise-storage-error", listener);
           };
-          cacheFile._hasAttemptedGetRequest = true;
           cacheFile.addEventListener("rise-storage-error", listener);
           cacheFile._handleCacheError({}, resp);
           assert.isTrue(responded);


### PR DESCRIPTION
@donnapep @stulees I have removed the GET request fallback as it will not be needed with CAP cache accepting HEAD request. I have tested and it all work. you can check it out working on presentation http://rva.risevision.com/#/PRESENTATION_MANAGE/id=93e6393b-2f78-4723-b411-dc020d4439e9?cid=30007b45-3df0-4c7b-9f7f-7d8ce6443013

and this version of CAP: https://github.com/Rise-Vision/player-chromeapp/pull/62

Please review. cheers