### PR TITLE
Add GET request fallback for a folder selection

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "authors": [
     "Donna Peplinskie <donna.peplinskie@risevision.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-component-rise-storage",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "The Rise Storage Web Component uses Google’s storage API to retrieve the URLs of all files in a particular folder, or the URL of a single file in a particular folder, from Rise Storage.",
   "scripts": {
     "test": "gulp test",

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -235,6 +235,24 @@
     _totalFilesBefore: 0,
 
     /**
+     * The list of items in a folder to request from Rise Cache.
+     *
+     * @property _folderFilesToRequest
+     * @type object
+     * @default []
+     */
+    _folderFilesToRequest: [],
+
+    /**
+     * The number of items in a folder that have been successfully requested from Rise Cache.
+     *
+     * @property _folderFilesToRequest
+     * @type object
+     * @default []
+     */
+    _folderFilesRequested: 0,
+
+    /**
      * Whether or not any of the files in a folder have changed.
      *
      * @property _isChanged
@@ -631,12 +649,12 @@
     },
 
     /**
-     * Make requests to Rise Cache to retrieve all files in a folder.
+     * Configures items to request to Rise Cache for retrieving all files in a folder.
      */
     _getFilesFromCache: function(resp) {
-
-      this._cacheRequestMethod = "HEAD";
-      this._hasAttemptedGetRequest = false;
+      // reset folder files to request list/count
+      this._folderFilesToRequest = [];
+      this._folderFilesRequested = 0;
 
       var self = this;
 
@@ -661,12 +679,28 @@
               return;
             }
 
-            self._setFileUrl(item);
-            self._cacheUrl = self._baseCacheUrl + "cb=" + new Date().getTime() + "?url=" + self._fileUrl;
-            self.$.cache.generateRequest();
+            // Add to list of folder files to request
+            self._folderFilesToRequest.push(item);
           }
         });
+
+        if (this._folderFilesToRequest.length > 0) {
+          // request the first folder file in the list
+          this._requestCacheFolderFile(this._folderFilesToRequest[0]);
+        }
       }
+    },
+
+    /**
+     * Makes a request to Rise Cache to retrieve a file from a folder.
+     */
+    _requestCacheFolderFile: function (item) {
+      this._cacheRequestMethod = "HEAD";
+      this._hasAttemptedGetRequest = false;
+
+      this._setFileUrl(item);
+      this._cacheUrl = this._baseCacheUrl + "cb=" + new Date().getTime() + "?url=" + this._fileUrl;
+      this.$.cache.generateRequest();
     },
 
     /**
@@ -677,6 +711,13 @@
         this._handleCacheFile(resp);
       }
       else {
+        this._folderFilesRequested += 1;
+
+        if (this._folderFilesToRequest.length > this._folderFilesRequested) {
+          // request the next folder file in the list
+          this._requestCacheFolderFile(this._folderFilesToRequest[this._folderFilesRequested]);
+        }
+
         this._handleCacheFolder(resp);
       }
     },
@@ -1213,6 +1254,8 @@
       this._isChanged = false;
       this._cacheRequestMethod = "HEAD";
       this._hasAttemptedGetRequest = false;
+      this._folderFilesToRequest = [];
+      this._folderFilesRequested = 0;
     }
   });
 </script>

--- a/test/unit/rise-cache.html
+++ b/test/unit/rise-cache.html
@@ -186,11 +186,14 @@
       });
 
       suite("_getFilesFromCache", function() {
+        var spy;
 
-        test("should correctly set the cache request method to HEAD", function() {
-          cacheFolder._getFilesFromCache(images);
-          assert.equal(cacheFolder._cacheRequestMethod, "HEAD");
-          assert.equal(cacheFolder._hasAttemptedGetRequest, false);
+        setup(function () {
+          spy = sinon.spy(cacheFolder, "_requestCacheFolderFile");
+        });
+
+        teardown(function () {
+          cacheFolder._requestCacheFolderFile.restore();
         });
 
         test("should correctly set number of total files in a folder", function() {
@@ -201,6 +204,26 @@
         test("should correctly set number of total files in a folder with subfolders", function() {
           cacheFolder._getFilesFromCache(imagesAndFolders);
           assert.equal(cacheFolder._totalFiles, 2);
+        });
+
+        test("should correctly set list of items in a folder to request", function () {
+          cacheFolder._getFilesFromCache(images);
+          assert.deepEqual(cacheFolder._folderFilesToRequest, images.files.slice(1));
+        });
+
+        test("should correctly request for first item in folder file list", function () {
+          cacheFolder._getFilesFromCache(images);
+          assert(spy.calledWith(images.files[1]));
+        });
+
+      });
+
+      suite("_requestCacheFolderFile", function () {
+
+        test("should correctly set the cache request method to HEAD", function() {
+          cacheFolder._requestCacheFolderFile(images.files[0]);
+          assert.equal(cacheFolder._cacheRequestMethod, "HEAD");
+          assert.equal(cacheFolder._hasAttemptedGetRequest, false);
         });
       });
 


### PR DESCRIPTION
- folder file requests occur upon successful response of previous folder file request, making an initial HEAD request and then a GET fallback request
- test coverage added
- version bump