### PR TITLE
Fixed bug where it was not calling storage metadata on refresh

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "authors": [
     "Donna Peplinskie <donna.peplinskie@risevision.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-component-rise-storage",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "The Rise Storage Web Component uses Google’s storage API to retrieve the URLs of all files in a particular folder, or the URL of a single file in a particular folder, from Rise Storage.",
   "scripts": {
     "test": "gulp test",

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -112,9 +112,15 @@
      */
 
     /**
-     * Fired when an error is received.
+     * Fired when an error is received from the storage.
      *
      * @event rise-storage-error
+     */
+
+    /**
+     * Fired when an error is received from cache.
+     *
+     * @event rise-cache-error
      */
 
     /**
@@ -387,10 +393,10 @@
         }
         else if (this._noFolderExists(resp.response)) {
           if (this.filename) {
-            this.fire("rise-storage-no-file");
+            this.fire("rise-storage-no-file", this.folder+"/"+this.filename);
           }
           else {
-            this.fire("rise-storage-no-folder");
+            this.fire("rise-storage-no-folder", this.folder);
           }
         }
         else {
@@ -875,7 +881,7 @@
       }
       else {
         this._startTimer();
-        this.fire("rise-storage-error", resp);
+        this.fire("rise-cache-error", resp);
       }
     },
 
@@ -952,24 +958,7 @@
         this.refresh = (this.refresh < 5) ? 5 : this.refresh;
 
         this.debounce("refresh", function() {
-          // File
-          if (this._isFile) {
-            if (this._isCacheRunning) {
-              if (this._fileThrottled) {
-                this._loadStorage();
-              }
-              else {
-                this._getFileFromCache();
-              }
-            }
-            else {
-              this._loadStorage();
-            }
-          }
-          // Folder
-          else {
-            this._loadStorage();
-          }
+          this._loadStorage();
         }, this.refresh * 60000);
       }
     },

--- a/test/integration/rise-cache.html
+++ b/test/integration/rise-cache.html
@@ -193,26 +193,6 @@
           server.respond();
         });
 
-        test("should make a request to Rise Cache after 5 minutes if a file that was throttled is no longer throttled", function(done) {
-          responseHandler = function(response) {
-            cacheFileFolder._fileThrottled = false;
-            timerSpy = sinon.spy(cacheFileFolder, "_getFileFromCache");
-
-            clock.tick(299999);
-            assert(timerSpy.notCalled);
-            clock.tick(300000);
-            assert(timerSpy.calledOnce);
-
-            cacheFileFolder.removeEventListener("rise-storage-file-throttled", responseHandler);
-
-            done();
-          };
-
-          cacheFileFolder.addEventListener("rise-storage-file-throttled", responseHandler);
-          server.respondWith([200, header, JSON.stringify(folderImage)]);
-          cacheFileFolder.go();
-          server.respond();
-        });
       });
     });
   </script>

--- a/test/integration/rise-storage.html
+++ b/test/integration/rise-storage.html
@@ -395,8 +395,8 @@
 
         test("should fire rise-storage-no-folder if a folder does not exist", function(done) {
           responseHandler = function(response) {
-            assert.isObject(response.detail, "response.detail is an object");
-            assert.deepEqual(response.detail, {}, "response.detail is an empty object");
+            assert.isString(response.detail, "response.detail is a String");
+            assert.deepEqual(response.detail, "images", "response.detail is the path to the file");
 
             folder.removeEventListener("rise-storage-no-folder", responseHandler);
 
@@ -467,8 +467,8 @@
 
         test("should fire rise-storage-no-file if a bucket file does not exist", function(done) {
           responseHandler = function(response) {
-            assert.isObject(response.detail, "response.detail is an object");
-            assert.deepEqual(response.detail, {}, "response.detail is an empty object");
+            assert.isString(response.detail, "response.detail is a String");
+            assert.deepEqual(response.detail, "/home.jpg", "response.detail is the path to the file");
 
             file.removeEventListener("rise-storage-no-file", responseHandler);
 
@@ -483,8 +483,8 @@
 
         test("should fire rise-storage-no-file if a folder file does not exist", function(done) {
           responseHandler = function(response) {
-            assert.isObject(response.detail, "response.detail is an object");
-            assert.deepEqual(response.detail, {}, "response.detail is an empty object");
+            assert.isString(response.detail, "response.detail is a String");
+            assert.deepEqual(response.detail, "images/home.jpg", "response.detail is the path to the file");
 
             fileFolder.removeEventListener("rise-storage-no-file", responseHandler);
 

--- a/test/unit/rise-cache.html
+++ b/test/unit/rise-cache.html
@@ -246,17 +246,17 @@
             },
             listener = function(response) {
               responded = true;
-              cacheFile.removeEventListener("rise-storage-error", listener);
+              cacheFile.removeEventListener("rise-cache-error", listener);
             };
           cacheFile._hasAttemptedGetRequest = false;
-          cacheFile.addEventListener("rise-storage-error", listener);
+          cacheFile.addEventListener("rise-cache-error", listener);
           cacheFile._handleCacheError({}, resp);
           assert.isFalse(responded);
           assert.equal(cacheFile._cacheRequestMethod, "GET");
           done();
         });
 
-        test("should fire rise-storage-error if there is a problem with the Rise Cache request", function(done) {
+        test("should fire rise-cache-error if there is a problem with the Rise Cache request", function(done) {
           var resp = {
             "xhr": {
               "status": 404,
@@ -265,10 +265,10 @@
           },
           listener = function(response) {
             responded = true;
-            cacheFile.removeEventListener("rise-storage-error", listener);
+            cacheFile.removeEventListener("rise-cache-error", listener);
           };
           cacheFile._hasAttemptedGetRequest = true;
-          cacheFile.addEventListener("rise-storage-error", listener);
+          cacheFile.addEventListener("rise-cache-error", listener);
           cacheFile._handleCacheError({}, resp);
           assert.isTrue(responded);
           done();
@@ -319,22 +319,10 @@
           assert.equal(cacheFolder.refresh, 5);
         });
 
-        test("should check for changes to a cached file", function() {
-          timerSpy = sinon.spy(cacheFile, "_getFileFromCache");
-
-          cacheFile.refresh = 5;
-          cacheFile._isFile = true;
-          cacheFile._isCacheRunning = true;
-          cacheFile._startTimer();
-
-          clock.tick(300000);
-          assert(timerSpy.calledOnce);
-        });
-
-        test("should check for changes to an uncached file", function() {
+        test("should check for changes to a file", function() {
           timerSpy = sinon.spy(cacheFile.$.storage, "generateRequest");
 
-          cacheFile._isCacheRunning = false;
+          cacheFile.refresh = 5;
           cacheFile._startTimer();
 
           clock.tick(300000);


### PR DESCRIPTION
Changed cache error to have its own event name rise-cache-error
Added the folder and files path to the rise-storage-no-file and
rise-storage-no-folder events
Fixed tests

@donnapep @stulees please review. cheers