### PR TITLE
Request for file(s) from Rise Cache on storage error

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "authors": [
     "Donna Peplinskie <donna.peplinskie@risevision.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-component-rise-storage",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "The Rise Storage Web Component uses Google’s storage API to retrieve the URLs of all files in a particular folder, or the URL of a single file in a particular folder, from Rise Storage.",
   "scripts": {
     "test": "gulp test",

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -450,8 +450,36 @@
      * Fires when an error is received from the Storage request.
      */
     _handleStorageError: function(e, resp) {
-      this._startTimer();
-      this.fire("rise-storage-error", resp);
+      var fireError = true;
+
+      if (!this._isLoading && this._isCacheRunning && !this._fileThrottled) {
+        // storage request initiated from a refresh, Rise Cache is running, and no flag of previous file being throttled
+
+        if (this._isFile) {
+          fireError = false;
+
+          // proceed with getting file from Rise Cache
+          this._getFileFromCache();
+        }
+        else {
+          // folder files
+          if (this._folderFilesToRequest.length > 0) {
+            fireError = false;
+
+            // reset the request list/count
+            this._folderFilesRequested = 0;
+
+            // request the first folder file in the list to get cycle started
+            this._requestCacheFolderFile(this._folderFilesToRequest[0]);
+          }
+        }
+
+      }
+
+      if (fireError) {
+        this._startTimer();
+        this.fire("rise-storage-error", resp);
+      }
     },
 
     /**
@@ -1245,6 +1273,7 @@
       this._hasAttemptedGetRequest = false;
       this._folderFilesToRequest = [];
       this._folderFilesRequested = 0;
+      this._fileThrottled = false;
     }
   });
 </script>

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -232,15 +232,6 @@
     _totalFiles: 0,
 
     /**
-     * The total number of files in a folder from the last request.
-     *
-     * @property _totalFilesBefore
-     * @type number
-     * @default 0
-     */
-    _totalFilesBefore: 0,
-
-    /**
      * The list of items in a folder to request from Rise Cache.
      *
      * @property _folderFilesToRequest
@@ -257,15 +248,6 @@
      * @default []
      */
     _folderFilesRequested: 0,
-
-    /**
-     * Whether or not any of the files in a folder have changed.
-     *
-     * @property _isChanged
-     * @type boolean
-     * @default false
-     */
-    _isChanged: false,
 
     /**
      * Whether or not a file is throttled.
@@ -694,8 +676,6 @@
 
       if (resp.files) {
         this._numFiles = 0;
-        this._isChanged = false;
-        this._totalFilesBefore = this._totalFiles;
 
         // Only count actual files (ignore folders)
         this._totalFiles = resp.files.filter(function(item) {
@@ -871,7 +851,6 @@
             else {
               previousItem.lastModified = lastModified;
               previousItem.fullUrl = file.url;
-              this._isChanged = true;
               file.changed = true;
             }
           }
@@ -887,12 +866,6 @@
       this._numFiles++;
 
       if (this._numFiles === this._totalFiles) {
-        // If number of files in the folder has changed, then file(s) have either been added
-        // or removed.
-        if (this._totalFiles !== this._totalFilesBefore) {
-          this._isChanged = true;
-        }
-
         this._startTimer();
         this._isLoading = false;
       }
@@ -1267,8 +1240,6 @@
       this._pingReceived = false;
       this._numFiles = 0;
       this._totalFiles = 0;
-      this._totalFilesBefore = 0;
-      this._isChanged = false;
       this._cacheRequestMethod = "HEAD";
       this._hasAttemptedGetRequest = false;
       this._folderFilesToRequest = [];

--- a/test/unit/rise-storage.html
+++ b/test/unit/rise-storage.html
@@ -110,22 +110,76 @@
       });
 
       suite("_handleStorageError", function() {
-        test("should fire rise-storage-error if Storage returns a 404 status code", function(done) {
-          var resp = {
-            "request": {
-              "status": 404,
-              "statusText": "An error occurred"
-            }
-          },
-          listener = function(response) {
-            responded = true;
-            fileBucket.removeEventListener("rise-storage-error", listener);
-          };
+        var resp = {
+          "request": {
+            "status": 404,
+            "statusText": "An error occurred"
+          }
+        }, errorSpy = null;
 
-          fileBucket.addEventListener("rise-storage-error", listener);
+        setup(function() {
+          errorSpy = sinon.spy();
+          fileBucket._reset();
+          fileBucket.addEventListener("rise-storage-error", errorSpy);
+          folder._reset();
+          folder.addEventListener("rise-storage-error", errorSpy);
+        });
+
+        teardown(function(){
+          fileBucket.removeEventListener("rise-storage-error", errorSpy);
+          folder.removeEventListener("rise-storage-error", errorSpy);
+        });
+
+        test("should fire rise-storage-error if Rise Cache is not running", function() {
           fileBucket._handleStorageError({}, resp);
-          assert.isTrue(responded);
-          done();
+          assert(errorSpy.calledOnce);
+        });
+
+        test("should fire rise-storage-error if Rise Cache is running but file previously determined to be throttled", function() {
+          fileBucket._isCacheRunning = true;
+          fileBucket._isLoading = false;
+          fileBucket._fileThrottled = true;
+
+          fileBucket._handleStorageError({}, resp);
+          assert(errorSpy.calledOnce);
+        });
+
+        test("should fire rise-storage-error if Rise Cache is running but no previous folder files to request", function() {
+          fileBucket._isCacheRunning = true;
+          fileBucket._isLoading = false;
+          fileBucket._isFile = false;
+
+          fileBucket._handleStorageError({}, resp);
+          assert(errorSpy.calledOnce);
+        });
+
+        test("should bypass firing error and proceed with getting file from Rise Cache", function() {
+          var getFileStub = sinon.stub(fileBucket, "_getFileFromCache", function(){});
+
+          fileBucket._isCacheRunning = true;
+          fileBucket._isLoading = false;
+          fileBucket._isFile = true;
+
+          fileBucket._handleStorageError({}, resp);
+          assert(getFileStub.calledOnce);
+          assert(errorSpy.notCalled);
+
+          fileBucket._getFileFromCache.restore();
+        });
+
+        test("should bypass firing error and proceed with getting folder files from Rise Cache", function() {
+          var requestFolderStub = sinon.stub(folder, "_requestCacheFolderFile", function(){});
+
+          folder._isCacheRunning = true;
+          folder._isLoading = false;
+          folder._isFile = false;
+          folder._folderFilesToRequest = ["", "", ""];
+
+          folder._handleStorageError({}, resp);
+          assert(requestFolderStub.calledOnce);
+          assert(errorSpy.notCalled);
+
+          folder._requestCacheFolderFile.restore();
         });
       });
 


### PR DESCRIPTION
- Upon a storage request error, conditionally request file(s) from Rise Cache instead of only firing "rise-storage-error" so that files could still potentially be provided
- Removing properties `_totalFilesBefore` and `_isChanged` as they are of no use in the component or tests
- Unit test coverage
- Minor version bump