### PR TITLE
Always sending rise-storage-response regardless of file(s) unchanged

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.2.7",
+  "version": "1.3.0",
   "authors": [
     "Donna Peplinskie <donna.peplinskie@risevision.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-component-rise-storage",
-  "version": "1.2.7",
+  "version": "1.3.0",
   "description": "The Rise Storage Web Component uses Google’s storage API to retrieve the URLs of all files in a particular folder, or the URL of a single file in a particular folder, from Rise Storage.",
   "scripts": {
     "test": "gulp test",

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -495,9 +495,7 @@
       else {
         // File hasn't changed.
         if (this._files[0].etag === etag) {
-          this._startTimer();
-
-          return;
+          file.changed = false;
         }
         else {
           this._files[0].etag = etag;
@@ -611,7 +609,7 @@
                       file.url = previousItem.url;
                     }
 
-                    file.unchanged = true;
+                    file.changed = false;
                   }
                   // File has changed.
                   else {
@@ -627,11 +625,9 @@
                 delete file.sortBy;
               }
 
-              if (!file.unchanged) {
-                file.name = self._getFileNameFromUrl(file.url);
+              file.name = self._getFileNameFromUrl(file.url);
 
-                self.fire("rise-storage-response", file);
-              }
+              self.fire("rise-storage-response", file);
             }
           }
         });
@@ -765,14 +761,10 @@
         else {
           // Rise Cache file hasn't changed.
           if (this._files[0].lastModified === lastModified) {
-            file.unchanged = true;
-            this._startTimer();
-
-            return;
+            file.changed = false;
           }
           else {
             this._files[0].lastModified = lastModified;
-            this.changed = true;
             file.changed = true;
           }
         }
@@ -845,7 +837,7 @@
             if (lastModified === previousItem.lastModified) {
               // Use the same URL as before in order to leverage browser caching.
               file.url = previousItem.fullUrl;
-              file.unchanged = true;
+              file.changed = false;
             }
             // File has changed.
             else {
@@ -856,11 +848,9 @@
           }
         }
 
-        if(!file.unchanged) {
-          file.name = this._getFileNameFromUrl(file.url);
+        file.name = this._getFileNameFromUrl(file.url);
 
-          this.fire("rise-storage-response", file);
-        }
+        this.fire("rise-storage-response", file);
       }
 
       this._numFiles++;

--- a/test/integration/rise-cache.html
+++ b/test/integration/rise-cache.html
@@ -42,20 +42,21 @@
       });
 
       suite("Rise Cache - bucket file", function() {
-        setup(function() {
+        suiteSetup(function () {
           cacheFile._reset();
           cacheFile._isCacheRunning = true;
           cacheFile._pingReceived = true;
           cacheFile._fileUrl = "https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fhome.jpg";
         });
 
+        teardown(function () {
+          cacheFile.removeEventListener("rise-storage-response", responseHandler);
+        });
+
         test("should return the correct URL for a specific file in a bucket", function(done) {
           responseHandler = function(response) {
             assert.equal(response.detail.name, "home.jpg");
             assert.equal(response.detail.url, "http://localhost:9494/?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fhome.jpg");
-
-            cacheFile.removeEventListener("rise-storage-response", responseHandler);
-
             done();
           };
 
@@ -65,33 +66,26 @@
           server.respond();
         });
 
-        test("should not fire rise-storage-response if the file hasn't changed", function(done) {
-          responseHandler = sinon.spy();
+        test("should fire rise-storage-response even if the file hasn't changed", function(done) {
+          responseHandler = function(response) {
+            assert.isFalse(response.detail.changed);
+            done();
+          };
 
           cacheFile.addEventListener("rise-storage-response", responseHandler);
           server.respondWith([200, cacheHeader, ""]);
           cacheFile._getFileFromCache();
           server.respond();
-
-          assert(responseHandler.notCalled);
-          done();
         });
 
         test("should return a new URL if the file has changed", function(done) {
           responseHandler = function(response) {
+            assert.isTrue(response.detail.changed);
             assert.equal(response.detail.name, "home.jpg");
             assert.equal(response.detail.url, "http://localhost:9494/cb=0?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fhome.jpg");
-
-            cacheFile.removeEventListener("rise-storage-response", responseHandler);
-
             done();
           };
 
-          cacheFile._files.push({
-            "name": "home.jpg", "lastModified": ""
-          });
-
-          cacheFile._isLoading = false;
           cacheFile.addEventListener("rise-storage-response", responseHandler);
           server.respondWith([200, newCacheHeader, ""]);
           cacheFile._getFileFromCache();
@@ -100,20 +94,22 @@
       });
 
       suite("Rise Cache - folder file", function() {
-        setup(function() {
+        suiteSetup(function () {
           cacheFileFolder._reset();
           cacheFileFolder._isCacheRunning = true;
           cacheFileFolder._pingReceived = true;
           cacheFileFolder._fileUrl = "https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fimages%252Fhome.jpg";
         });
 
+        teardown(function () {
+          cacheFileFolder.removeEventListener("rise-storage-response", responseHandler);
+        });
+
         test("should return the correct URL for a specific file in a folder", function(done) {
           responseHandler = function(response) {
+            assert.isTrue(response.detail.added);
             assert.equal(response.detail.name, "images/home.jpg");
             assert.equal(response.detail.url, "http://localhost:9494/?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fimages%252Fhome.jpg");
-
-            cacheFileFolder.removeEventListener("rise-storage-response", responseHandler);
-
             done();
           };
 
@@ -123,33 +119,26 @@
           server.respond();
         });
 
-        test("should not fire rise-storage-response if the file hasn't changed", function(done) {
-          responseHandler = sinon.spy();
+        test("should fire rise-storage-response even if the file hasn't changed", function(done) {
+          responseHandler = function(response) {
+            assert.isFalse(response.detail.changed);
+            done();
+          };
 
           cacheFileFolder.addEventListener("rise-storage-response", responseHandler);
           server.respondWith([200, cacheHeader, ""]);
           cacheFileFolder._getFileFromCache();
           server.respond();
-
-          assert(responseHandler.notCalled);
-          done();
         });
 
         test("should return a new URL if the file has changed", function(done) {
           responseHandler = function(response) {
+            assert.isTrue(response.detail.changed);
             assert.equal(response.detail.name, "images/home.jpg");
             assert.equal(response.detail.url, "http://localhost:9494/cb=0?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fimages%252Fhome.jpg");
-
-            cacheFileFolder.removeEventListener("rise-storage-response", responseHandler);
-
             done();
           };
 
-          cacheFileFolder._files.push({
-            "name": "risemedialibrary-abc123/images/home.jpg", "lastModified": ""
-          });
-
-          cacheFileFolder._isLoading = false;
           cacheFileFolder.addEventListener("rise-storage-response", responseHandler);
           server.respondWith([200, newCacheHeader, ""]);
           cacheFileFolder._getFileFromCache();
@@ -163,11 +152,6 @@
         suiteSetup(function() {
           folderImage.files[0].isThrottled = true;
         });
-
-        setup (function() {
-          cacheFileFolder._pingReceived = true;
-          cacheFileFolder._isCacheRunning = true;
-        })
 
         suiteTeardown(function() {
           folderImage.files[0].isThrottled = false;

--- a/test/integration/rise-storage.html
+++ b/test/integration/rise-storage.html
@@ -70,20 +70,21 @@
           server.respond();
         });
 
-        test("should not fire rise-storage-response if the file hasn't changed", function(done) {
-          responseHandler = sinon.spy();
+        test("should fire rise-storage-response if the file hasn't changed", function(done) {
+          responseHandler = function(response) {
+            assert.isFalse(response.detail.changed);
+            done();
+          };
 
           file.addEventListener("rise-storage-response", responseHandler);
           server.respondWith([200, header, JSON.stringify(bucketImage)]);
           file.go();
           server.respond();
-
-          assert(responseHandler.notCalled);
-          done();
         });
 
         test("should return a new URL if the file has changed", function(done) {
           responseHandler = function(response) {
+            assert.isTrue(response.detail.changed);
             assert.equal(response.detail.name, "home.jpg");
             assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media&cb=0");
             done();
@@ -102,7 +103,7 @@
       suite("file in a folder", function() {
         var localFolderImage;
 
-        setup(function() {
+        suiteSetup(function() {
           fileFolder._reset();
           fileFolder._isCacheRunning = false;
           fileFolder._pingReceived = true;
@@ -127,39 +128,26 @@
           server.respond();
         });
 
-        test("should not fire rise-storage-response if the file hasn't changed", function(done) {
-          responseHandler = sinon.spy();
-
-          fileFolder.addEventListener("rise-storage-response", responseHandler);
-          server.respondWith([200, header, JSON.stringify(folderImage)]);
-          fileFolder.go();
-          server.respond();
-
-          assert(responseHandler.notCalled);
-          done();
-        });
-
-        test("should return a new URL if the file has changed", function(done) {
-          var files = [];
-
+        test("should fire rise-storage-response if the file hasn't changed", function(done) {
           responseHandler = function(response) {
-            files.push(response.detail);
-
-            if(files.length === 2) {
-              assert.equal(files[0].name, "images/home.jpg");
-              assert.equal(files[1].name, "images/home.jpg");
-              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
-              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&cb=0");
-              assert.isTrue(files[0].added);
-              assert.isTrue(files[1].changed);
-              done();
-            }
+            assert.isFalse(response.detail.changed);
+            done();
           };
 
           fileFolder.addEventListener("rise-storage-response", responseHandler);
           server.respondWith([200, header, JSON.stringify(folderImage)]);
           fileFolder.go();
           server.respond();
+        });
+
+        test("should return a new URL if the file has changed", function(done) {
+          responseHandler = function(response) {
+            assert.isTrue(response.detail.changed);
+            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&cb=0");
+            done();
+          };
+
+          fileFolder.addEventListener("rise-storage-response", responseHandler);
 
           folderImage.files[0].etag = "new";
 
@@ -172,7 +160,7 @@
       suite("folder", function() {
         var localImages;
 
-        setup(function() {
+        suiteSetup(function() {
           folder._reset();
           folder._isCacheRunning = false;
           folder._pingReceived = true;
@@ -201,34 +189,20 @@
             }
           };
 
+
           folder.addEventListener("rise-storage-response", responseHandler);
           server.respondWith([200, header, JSON.stringify(images)]);
           folder.go();
           server.respond();
         });
 
-        test("should not send notifications if none of the files have changed", function(done) {
-          responseHandler = sinon.spy();
+        test("should send notifications even if none of the files have changed", function(done) {
+          var count = 0;
 
-          folder.addEventListener("rise-storage-response", responseHandler);
-          server.respondWith([200, header, JSON.stringify(images)]);
-          folder.go();
-          server.respond();
+          responseHandler = function (response) {
+            count += 1;
 
-          assert(responseHandler.notCalled);
-          done();
-        });
-
-        test("should return a new URL if a file has changed", function(done) {
-          var files = [];
-
-          responseHandler = function(response) {
-            files.push(response.detail);
-
-            if(files.length === 4) {
-              assert.equal(files[3].name, "images/circle.png");
-              assert.equal(files[3].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&cb=0");
-              assert.isTrue(files[3].changed);
+            if (count === 3) {
               done();
             }
           };
@@ -237,31 +211,37 @@
           folder.addEventListener("rise-storage-response", responseHandler);
           folder.go();
           server.respond();
+        });
+
+        test("should return a new URL if a file has changed", function(done) {
+          responseHandler = function(response) {
+            if (response.detail.changed) {
+              assert.equal(response.detail.name, "images/circle.png");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&cb=0");
+              done();
+            }
+          };
 
           images.files[2].etag = "new";
 
           server.respondWith([200, header, JSON.stringify(images)]);
+          folder.addEventListener("rise-storage-response", responseHandler);
           folder.go();
           server.respond();
         });
 
         test("should return URL of a file that has been added to a folder", function(done) {
-          var files = [];
+          var count = 0;
 
           responseHandler = function(response) {
-            files.push(response.detail);
+            count += 1;
 
-            if(files.length === 4) {
-              assert.equal(files[3].name, "images/golf.svg");
-              assert.equal(files[3].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&cb=0");
+            if (response.detail.added && count > 3) {
+              assert.equal(response.detail.name, "images/golf.svg");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&cb=0");
               done();
             }
           };
-
-          server.respondWith([200, header, JSON.stringify(images)]);
-          folder.addEventListener("rise-storage-response", responseHandler);
-          folder.go();
-          server.respond();
 
           images.files.push({
             "name": "images/golf.svg",
@@ -272,41 +252,24 @@
           });
 
           server.respondWith([200, header, JSON.stringify(images)]);
+          folder.addEventListener("rise-storage-response", responseHandler);
           folder.go();
           server.respond();
         });
 
-        test("should not return URL of a file that has been removed from a folder", function(done) {
-          var files = [];
-
+        test("should return URL of a file that has been removed from a folder", function(done) {
           responseHandler = function(response) {
-            files.push(response.detail);
-
-            if(files.length === 4) {
-              assert.equal(files[0].name, "images/home.jpg");
-              assert.equal(files[1].name, "images/circle.png");
-              assert.equal(files[2].name, "images/my-image.bmp");
-              assert.equal(files[3].name, "images/my-image.bmp");
-              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
-              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media");
-              assert.equal(files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media");
-              assert.equal(files[3].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media");
-              assert.isTrue(files[3].deleted);
+            if (response.detail.deleted) {
+              assert.equal(response.detail.name, "images/golf.svg");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&cb=0");
               done();
             }
-            else if(files.length > 4) {
-              assert.isTrue(false);
-            }
           };
-
-          server.respondWith([200, header, JSON.stringify(images)]);
-          folder.addEventListener("rise-storage-response", responseHandler);
-          folder.go();
-          server.respond();
 
           images.files.pop();
 
           server.respondWith([200, header, JSON.stringify(images)]);
+          folder.addEventListener("rise-storage-response", responseHandler);
           folder.go();
           server.respond();
         });

--- a/test/unit/rise-cache.html
+++ b/test/unit/rise-cache.html
@@ -47,7 +47,7 @@
       suite("Rise Cache", function() {
         var localImages;
 
-        setup(function() {
+        suiteSetup(function () {
           cacheFolder._reset();
           cacheFolder._isCacheRunning = true;
           localImages = JSON.parse(JSON.stringify(images));
@@ -55,6 +55,7 @@
 
         teardown(function() {
           images = localImages;
+          cacheFolder.removeEventListener("rise-storage-response", listener);
         });
 
         test("should return the correct URLs for files in a folder", function(done) {
@@ -71,7 +72,6 @@
               assert.equal(files[0].url, "http://localhost:9494/?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fhome.jpg%3Falt%3Dmedia");
               assert.equal(files[1].url, "http://localhost:9494/?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fcircle.png%3Falt%3Dmedia");
               assert.equal(files[2].url, "http://localhost:9494/?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fmy-image.bmp%3Falt%3Dmedia");
-              cacheFolder.removeEventListener("rise-storage-response", listener);
             }
           };
 
@@ -82,28 +82,24 @@
           done();
         });
 
-        test("should return new URLs if none of the files have changed", function(done) {
-          var listener = sinon.spy();
-
-          cacheFolder._handleStorageFolder(images);
+        test("should return URLs even if none of the files have changed", function(done) {
+          listener = sinon.spy();
 
           cacheFolder.addEventListener("rise-storage-response", listener);
           cacheFolder._handleStorageFolder(images);
 
-          assert.isTrue(listener.notCalled);
+          assert.equal(listener.callCount, 3);
           done();
         });
 
         test("should return new URL if a file has changed", function(done) {
-          var listener = function(response) {
-            responded = true;
-            assert.equal(response.detail.name, "images/circle.png");
-            assert.equal(response.detail.url, "http://localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fcircle.png%3Falt%3Dmedia");
-            assert.isTrue(response.detail.changed);
-            cacheFolder.removeEventListener("rise-storage-response", listener);
+          listener = function(response) {
+            if (response.detail.changed) {
+              responded = true;
+              assert.equal(response.detail.name, "images/circle.png");
+              assert.equal(response.detail.url, "http://localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fcircle.png%3Falt%3Dmedia");
+            }
           };
-
-          cacheFolder._handleStorageFolder(images);
 
           images.files[2].etag = "new";
           cacheFolder.addEventListener("rise-storage-response", listener);
@@ -114,14 +110,13 @@
         });
 
         test("should return URL of a file that has been added to a folder", function(done) {
-          var listener = function(response) {
-            responded = true;
-            assert.equal(response.detail.name, "images/golf.svg");
-            assert.equal(response.detail.url, "http://localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia");
-            cacheFolder.removeEventListener("rise-storage-response", listener);
+          listener = function(response) {
+            if (response.detail.added) {
+              responded = true;
+              assert.equal(response.detail.name, "images/golf.svg");
+              assert.equal(response.detail.url, "http://localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia");
+            }
           };
-
-          cacheFolder._handleStorageFolder(images);
 
           images.files.push({
             "name": "images/golf.svg",
@@ -137,15 +132,15 @@
           done();
         });
 
-        test("should not return URL of a file that has been removed from a folder", function(done) {
-          var listener = function(response) {
-            responded = true;
-            assert.equal(response.detail.name, "images/my-image.bmp");
-            assert.equal(response.detail.url, "http://localhost:9494/?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fmy-image.bmp%3Falt%3Dmedia");
-            cacheFolder.removeEventListener("rise-storage-response", listener);
+        test("should return URL of a file that has been removed from a folder", function(done) {
+          listener = function(response) {
+            if (response.detail.deleted) {
+              responded = true;
+              assert.equal(response.detail.name, "images/golf.svg");
+              assert.equal(response.detail.url, "http://localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia");
+              cacheFolder.removeEventListener("rise-storage-response", listener);
+            }
           };
-
-          cacheFolder._handleStorageFolder(images);
 
           images.files.pop();
           cacheFolder.addEventListener("rise-storage-response", listener);

--- a/test/unit/rise-storage.html
+++ b/test/unit/rise-storage.html
@@ -187,8 +187,12 @@
         suite("bucket file", function() {
           var url = bucketImage.files[0].selfLink;
 
-          setup(function() {
+          suiteSetup(function () {
             fileBucket._reset();
+          });
+
+          teardown(function () {
+            fileBucket.removeEventListener("rise-storage-response", listener);
           });
 
           test("should return the correct URL for a specific file in a bucket", function(done) {
@@ -196,7 +200,6 @@
               responded = true;
               assert.equal(response.detail.name, "home.jpg");
               assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media");
-              fileBucket.removeEventListener("rise-storage-response", listener);
             };
 
             fileBucket.addEventListener("rise-storage-response", listener);
@@ -207,31 +210,29 @@
             done();
           });
 
-          test("should not fire rise-storage-response if the file hasn't changed", function(done) {
+          test("should fire rise-storage-response if the file hasn't changed", function(done) {
             listener = function(response) {
               responded = true;
+              assert.isFalse(response.detail.changed);
+              fileBucket.removeEventListener("rise-storage-response", listener);
             };
 
-            fileBucket._fileUrl = url + suffix;
-            fileBucket._handleStorageFile(bucketImage);
             fileBucket.addEventListener("rise-storage-response", listener);
             fileBucket._handleStorageFile(bucketImage);
-            fileBucket.removeEventListener("rise-storage-response", listener);
 
-            assert.isFalse(responded);
+            assert.isTrue(responded);
             done();
           });
 
           test("should return a new URL if the file has changed", function(done) {
             listener = function(response) {
               responded = true;
+              assert.isTrue(response.detail.changed);
               assert.equal(response.detail.name, "home.jpg");
               assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media&cb=0");
               fileBucket.removeEventListener("rise-storage-response", listener);
             };
 
-            fileBucket._fileUrl = url + suffix;
-            fileBucket._handleStorageFile(bucketImage);
             bucketImage.files[0].etag = "new";
             fileBucket.addEventListener("rise-storage-response", listener);
             fileBucket._handleStorageFile(bucketImage);
@@ -247,8 +248,12 @@
         suite("folder file", function() {
           var url = folderImage.files[0].selfLink;
 
-          setup(function() {
+          suiteSetup(function () {
             fileFolder._reset();
+          });
+
+          teardown(function() {
+            fileFolder.removeEventListener("rise-storage-response", listener);
           });
 
           test("should return the correct URL for a specific file in a bucket", function(done) {
@@ -256,7 +261,6 @@
               responded = true;
               assert.equal(response.detail.name, "images/home.jpg");
               assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
-              fileFolder.removeEventListener("rise-storage-response", listener);
             };
 
             fileFolder.addEventListener("rise-storage-response", listener);
@@ -267,31 +271,27 @@
             done();
           });
 
-          test("should not fire rise-storage-response if the file hasn't changed", function(done) {
+          test("should fire rise-storage-response if the file hasn't changed", function(done) {
             listener = function(response) {
               responded = true;
+              assert.isFalse(response.detail.changed);
             };
 
-            fileFolder._fileUrl = url + suffix;
-            fileFolder._handleStorageFile(folderImage);
             fileFolder.addEventListener("rise-storage-response", listener);
             fileFolder._handleStorageFile(folderImage);
-            fileFolder.removeEventListener("rise-storage-response", listener);
 
-            assert.isFalse(responded);
+            assert.isTrue(responded);
             done();
           });
 
           test("should return a new URL if the file has changed", function(done) {
             listener = function(response) {
               responded = true;
+              assert.isTrue(response.detail.changed);
               assert.equal(response.detail.name, "images/home.jpg");
               assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&cb=0");
-              fileFolder.removeEventListener("rise-storage-response", listener);
             };
 
-            fileFolder._fileUrl = url + suffix;
-            fileFolder._handleStorageFile(folderImage);
             folderImage.files[0].etag = "new";
             fileFolder.addEventListener("rise-storage-response", listener);
             fileFolder._handleStorageFile(folderImage);
@@ -308,7 +308,7 @@
       suite("_handleStorageFolder", function() {
         var localImages;
 
-        setup(function() {
+        suiteSetup(function () {
           folder._reset();
           localImages = JSON.parse(JSON.stringify(images));
         });
@@ -331,7 +331,6 @@
               assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
               assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media");
               assert.equal(files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media");
-              folder.removeEventListener("rise-storage-response", listener);
             }
           };
 
@@ -356,7 +355,6 @@
               assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
               assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media");
               assert.equal(files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media");
-              folder.removeEventListener("rise-storage-response", listener);
             }
           };
 
@@ -369,14 +367,12 @@
 
         test("should return new URL if a file has changed", function(done) {
           listener = function(response) {
-            responded = true;
-            assert.equal(response.detail.name, "images/circle.png");
-            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&cb=0");
-            assert.isTrue(response.detail.changed);
-            folder.removeEventListener("rise-storage-response", listener);
+            if (response.detail.changed) {
+              responded = true;
+              assert.equal(response.detail.name, "images/circle.png");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&cb=0");
+            }
           };
-
-          folder._handleStorageFolder(images);
 
           images.files[2].etag = "new";
           folder.addEventListener("rise-storage-response", listener);
@@ -388,14 +384,12 @@
 
         test("should return URL of a file that has been added to a folder", function(done) {
           listener = function(response) {
-            responded = true;
-            assert.equal(response.detail.name, "images/golf.svg");
-            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&cb=0");
-            assert.isTrue(response.detail.added);
-            folder.removeEventListener("rise-storage-response", listener);
+            if (response.detail.added) {
+              responded = true;
+              assert.equal(response.detail.name, "images/golf.svg");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&cb=0");
+            }
           };
-
-          folder._handleStorageFolder(images);
 
           images.files.push({
             "name": "images/golf.svg",
@@ -412,15 +406,14 @@
           done();
         });
 
-        test("should not return URL of a file that has been removed from a folder", function(done) {
-          var listener = function(response) {
-            responded = true;
-            assert.equal(response.detail.name, "images/my-image.bmp");
-            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media");
-            folder.removeEventListener("rise-storage-response", listener);
+        test("should return URL of a file that has been removed from a folder", function(done) {
+          listener = function(response) {
+            if (response.detail.deleted) {
+              responded = true;
+              assert.equal(response.detail.name, "images/golf.svg");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&cb=0");
+            }
           };
-
-          folder._handleStorageFolder(images);
 
           images.files.pop();
           folder.addEventListener("rise-storage-response", listener);
@@ -509,7 +502,7 @@
           assert.equal(fileBucket._isThrottled(resp, 0), false);
         });
 
-        test("should return false if file has no isThrottled property", function() {debugger;
+        test("should return false if file has no isThrottled property", function() {
           resp.files = [{}];
 
           assert.equal(fileBucket._isThrottled(resp, 0), false);


### PR DESCRIPTION
- For handling both file and folder files (cache running or not), "rise-storage-response" is now always fired. If file(s) haven't changed, `changed` property is still provided to the file object with a value of `false`
- Refactored unit and integration tests
- Feature version bump