### PR TITLE
Removing the use of a cachebuster

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "authors": [
     "Donna Peplinskie <donna.peplinskie@risevision.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-component-rise-storage",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "The Rise Storage Web Component uses Google’s storage API to retrieve the URLs of all files in a particular folder, or the URL of a single file in a particular folder, from Rise Storage.",
   "scripts": {
     "test": "gulp test",

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -191,7 +191,7 @@
      *
      * @property _baseCacheUrl
      * @type string
-     * @default "http://localhost:9494/cb="
+     * @default "http://localhost:9494/"
      */
     _baseCacheUrl: "http://localhost:9494/",
 
@@ -499,7 +499,6 @@
         }
         else {
           this._files[0].etag = etag;
-          file.url += "&cb=" + new Date().getTime();
           file.changed = true;
         }
       }
@@ -517,8 +516,7 @@
       var self = this,
         file = {},
         previousItem = null,
-        suffix = "?alt=media",
-        cb = "&cb=" + new Date().getTime();
+        suffix = "?alt=media";
 
       if (resp.files) {
         if (this.sort) {
@@ -575,10 +573,10 @@
               else {
                 // Construct URL.
                 if (self._isCacheRunning) {
-                  file.url = self._baseCacheUrl + "cb=" + new Date().getTime() + "?url=" + encodeURIComponent(item.selfLink + suffix);
+                  file.url = self._baseCacheUrl + "?url=" + encodeURIComponent(item.selfLink + suffix);
                 }
                 else if(!self._isOfflinePlayer()) {
-                  file.url = item.selfLink + suffix + cb;
+                  file.url = item.selfLink + suffix;
                 }
                 else {
                   file.url = item.selfLink;
@@ -648,14 +646,7 @@
       this._cacheRequestMethod = "HEAD";
       this._hasAttemptedGetRequest = false;
 
-      if (this._isLoading) {
-        this._cacheUrl = this._baseCacheUrl + "?url=" + this._fileUrl;
-      }
-      else {
-        // Include a cache buster as this will be the URL that gets passed to the browser
-        // if the file has changed.
-        this._cacheUrl = this._baseCacheUrl + "cb=" + new Date().getTime() + "?url=" + this._fileUrl;
-      }
+      this._cacheUrl = this._baseCacheUrl + "?url=" + this._fileUrl;
 
       this.$.cache.generateRequest();
     },
@@ -709,7 +700,7 @@
       this._hasAttemptedGetRequest = false;
 
       this._setFileUrl(item);
-      this._cacheUrl = this._baseCacheUrl + "cb=" + new Date().getTime() + "?url=" + this._fileUrl;
+      this._cacheUrl = this._baseCacheUrl + "?url=" + this._fileUrl;
       this.$.cache.generateRequest();
     },
 

--- a/test/integration/rise-cache.html
+++ b/test/integration/rise-cache.html
@@ -78,11 +78,11 @@
           server.respond();
         });
 
-        test("should return a new URL if the file has changed", function(done) {
+        test("should return a URL if the file has changed", function(done) {
           responseHandler = function(response) {
             assert.isTrue(response.detail.changed);
             assert.equal(response.detail.name, "home.jpg");
-            assert.equal(response.detail.url, "http://localhost:9494/cb=0?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fhome.jpg");
+            assert.equal(response.detail.url, "http://localhost:9494/?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fhome.jpg");
             done();
           };
 
@@ -131,11 +131,11 @@
           server.respond();
         });
 
-        test("should return a new URL if the file has changed", function(done) {
+        test("should return a URL if the file has changed", function(done) {
           responseHandler = function(response) {
             assert.isTrue(response.detail.changed);
             assert.equal(response.detail.name, "images/home.jpg");
-            assert.equal(response.detail.url, "http://localhost:9494/cb=0?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fimages%252Fhome.jpg");
+            assert.equal(response.detail.url, "http://localhost:9494/?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fimages%252Fhome.jpg");
             done();
           };
 

--- a/test/integration/rise-storage.html
+++ b/test/integration/rise-storage.html
@@ -82,11 +82,11 @@
           server.respond();
         });
 
-        test("should return a new URL if the file has changed", function(done) {
+        test("should return a URL if the file has changed", function(done) {
           responseHandler = function(response) {
             assert.isTrue(response.detail.changed);
             assert.equal(response.detail.name, "home.jpg");
-            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media&cb=0");
+            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media");
             done();
           };
 
@@ -140,10 +140,10 @@
           server.respond();
         });
 
-        test("should return a new URL if the file has changed", function(done) {
+        test("should return a URL if the file has changed", function(done) {
           responseHandler = function(response) {
             assert.isTrue(response.detail.changed);
-            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&cb=0");
+            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
             done();
           };
 
@@ -213,11 +213,11 @@
           server.respond();
         });
 
-        test("should return a new URL if a file has changed", function(done) {
+        test("should return a URL if a file has changed", function(done) {
           responseHandler = function(response) {
             if (response.detail.changed) {
               assert.equal(response.detail.name, "images/circle.png");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&cb=0");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media");
               done();
             }
           };
@@ -238,7 +238,7 @@
 
             if (response.detail.added && count > 3) {
               assert.equal(response.detail.name, "images/golf.svg");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&cb=0");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media");
               done();
             }
           };
@@ -261,7 +261,7 @@
           responseHandler = function(response) {
             if (response.detail.deleted) {
               assert.equal(response.detail.name, "images/golf.svg");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&cb=0");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media");
               done();
             }
           };

--- a/test/unit/rise-cache.html
+++ b/test/unit/rise-cache.html
@@ -92,12 +92,12 @@
           done();
         });
 
-        test("should return new URL if a file has changed", function(done) {
+        test("should return URL if a file has changed", function(done) {
           listener = function(response) {
             if (response.detail.changed) {
               responded = true;
               assert.equal(response.detail.name, "images/circle.png");
-              assert.equal(response.detail.url, "http://localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fcircle.png%3Falt%3Dmedia");
+              assert.equal(response.detail.url, "http://localhost:9494/?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fcircle.png%3Falt%3Dmedia");
             }
           };
 
@@ -114,7 +114,7 @@
             if (response.detail.added) {
               responded = true;
               assert.equal(response.detail.name, "images/golf.svg");
-              assert.equal(response.detail.url, "http://localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia");
+              assert.equal(response.detail.url, "http://localhost:9494/?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia");
             }
           };
 
@@ -137,7 +137,7 @@
             if (response.detail.deleted) {
               responded = true;
               assert.equal(response.detail.name, "images/golf.svg");
-              assert.equal(response.detail.url, "http://localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia");
+              assert.equal(response.detail.url, "http://localhost:9494/?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia");
               cacheFolder.removeEventListener("rise-storage-response", listener);
             }
           };
@@ -176,7 +176,7 @@
         test("should correctly set the cache URL when not loading", function() {
           cacheFile._isLoading = false;
           cacheFile._getFileFromCache();
-          assert.equal(cacheFile._cacheUrl, "http://localhost:9494/cb=0?url=http://url.to.my.file");
+          assert.equal(cacheFile._cacheUrl, "http://localhost:9494/?url=http://url.to.my.file");
         });
       });
 

--- a/test/unit/rise-storage.html
+++ b/test/unit/rise-storage.html
@@ -224,12 +224,12 @@
             done();
           });
 
-          test("should return a new URL if the file has changed", function(done) {
+          test("should return a URL if the file has changed", function(done) {
             listener = function(response) {
               responded = true;
               assert.isTrue(response.detail.changed);
               assert.equal(response.detail.name, "home.jpg");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media&cb=0");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media");
               fileBucket.removeEventListener("rise-storage-response", listener);
             };
 
@@ -284,12 +284,12 @@
             done();
           });
 
-          test("should return a new URL if the file has changed", function(done) {
+          test("should return a URL if the file has changed", function(done) {
             listener = function(response) {
               responded = true;
               assert.isTrue(response.detail.changed);
               assert.equal(response.detail.name, "images/home.jpg");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&cb=0");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
             };
 
             folderImage.files[0].etag = "new";
@@ -365,12 +365,12 @@
           done();
         });
 
-        test("should return new URL if a file has changed", function(done) {
+        test("should return a URL if a file has changed", function(done) {
           listener = function(response) {
             if (response.detail.changed) {
               responded = true;
               assert.equal(response.detail.name, "images/circle.png");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&cb=0");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media");
             }
           };
 
@@ -387,7 +387,7 @@
             if (response.detail.added) {
               responded = true;
               assert.equal(response.detail.name, "images/golf.svg");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&cb=0");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media");
             }
           };
 
@@ -411,7 +411,7 @@
             if (response.detail.deleted) {
               responded = true;
               assert.equal(response.detail.name, "images/golf.svg");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&cb=0");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media");
             }
           };
 


### PR DESCRIPTION
- Both storage and rise cache file urls now do not apply a cachebuster
- Test coverage revised
- Minor patch version bump