### PR TITLE
Send event when folder only contains files of the wrong file type format

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ The web component returns a JSON response for each file matching the provided cr
 | `rise-storage-no-folder`      | Fired when the request is for a folder that does not exist.         |
 | `rise-storage-no-file`        | Fired when the request is for a file that does not exist.           |
 | `rise-storage-file-throttled` | Fired when the request is for a file that has been throttled.       |
+| `rise-storage-folder-invalid`| Fired when the request is for a folder that only contains files of the wrong file type format.     
 
 
 ### Methods

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "authors": [
     "Donna Peplinskie <donna.peplinskie@risevision.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-component-rise-storage",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "The Rise Storage Web Component uses Google’s storage API to retrieve the URLs of all files in a particular folder, or the URL of a single file in a particular folder, from Rise Storage.",
   "scripts": {
     "test": "gulp test",

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -518,7 +518,9 @@
         file = {},
         previousItem = null,
         suffix = "?alt=media",
-        cb = "&cb=" + new Date().getTime();
+        cb = "&cb=" + new Date().getTime(),
+        filesFiltered = 0,
+        totalFiles = 0;
 
       if (resp.files) {
         if (this.sort) {
@@ -548,7 +550,10 @@
           // Check that current item is not a folder.
           if (item.name && (item.name.slice(-1) !== "/")) {
             if (item.selfLink !== undefined) {
+              totalFiles += 1;
+
               if (!self._filterFiles(item.contentType)) {
+                filesFiltered += 1;
                 return;
               }
 
@@ -634,7 +639,15 @@
 
         this._processRemovedFiles(resp.files);
         this._isLoading = false;
-        this._startTimer();
+
+        if (totalFiles === filesFiltered) {
+          // notify that no valid files are in folder, wrong formats
+          this.fire("rise-storage-folder-invalid");
+        }
+        else {
+          this._startTimer();
+        }
+
       }
     },
 
@@ -697,6 +710,10 @@
         if (this._folderFilesToRequest.length > 0) {
           // request the first folder file in the list
           this._requestCacheFolderFile(this._folderFilesToRequest[0]);
+        }
+        else {
+          // notify that no valid files are in folder, wrong formats
+          this.fire("rise-storage-folder-invalid");
         }
       }
     },

--- a/test/integration/rise-storage.html
+++ b/test/integration/rise-storage.html
@@ -16,6 +16,7 @@
   <rise-storage id="file-folder" companyId="abc123" folder="images" fileName="home.jpg" refresh="5"></rise-storage>
   <rise-storage id="file-type" companyId="abc123" folder="my-folder" fileType="image"></rise-storage>
   <rise-storage id="content-type" companyId="abc123" folder="my-folder" contentType="image/jpeg image/bmp"></rise-storage>
+  <rise-storage id="folder-invalid" companyId="abc123" folder="images" fileType="video"></rise-storage>
 
   <script src="../js/rise-storage-data.js"></script>
   <script>
@@ -27,6 +28,7 @@
         file = document.querySelector("#file"),
         fileFolder = document.querySelector("#file-folder"),
         fileType = document.querySelector("#file-type"),
+        invalidFolder = document.querySelector("#folder-invalid"),
         contentType = document.querySelector("#content-type"),
         cacheHeader = { "Last-Modified": "Fri, 01 May 2015 15:32:11 GMT" };
 
@@ -591,6 +593,44 @@
           folder.addEventListener("rise-storage-file-throttled", responseHandler);
           server.respondWith([200, header, JSON.stringify(images)]);
           folder.go();
+          server.respond();
+
+          assert(responseHandler.notCalled);
+          done();
+        });
+      });
+
+      suite("rise-storage-folder-invalid", function() {
+        setup(function() {
+          invalidFolder._reset();
+          invalidFolder._isCacheRunning = false;
+          invalidFolder._pingReceived = true;
+        });
+
+        teardown(function() {
+          invalidFolder.removeEventListener("rise-storage-folder-invalid", responseHandler);
+        });
+
+        test("should fire rise-storage-folder-invalid if no valid files exist in folder", function(done) {
+          responseHandler = function(response) {
+            assert.isObject(response.detail, "response.detail is an object");
+            assert.deepEqual(response.detail, {}, "response.detail is an empty object");
+
+            done();
+          };
+
+          invalidFolder.addEventListener("rise-storage-folder-invalid", responseHandler);
+          server.respondWith([200, header, JSON.stringify(images)]);
+          invalidFolder.go();
+          server.respond();
+        });
+
+        test("should not fire rise-storage-folder-invalid if folder does contain a valid file format", function(done) {
+          responseHandler = sinon.spy();
+
+          invalidFolder.addEventListener("rise-storage-folder-invalid", responseHandler);
+          server.respondWith([200, header, JSON.stringify(mixedMedia)]);
+          invalidFolder.go();
           server.respond();
 
           assert(responseHandler.notCalled);

--- a/test/unit/rise-cache.html
+++ b/test/unit/rise-cache.html
@@ -13,6 +13,7 @@
 <body>
   <rise-storage id="cache-folder" companyId="abc123" folder="images"></rise-storage>
   <rise-storage id="cache-file" companyId="abc123" fileName="home.jpg"></rise-storage>
+  <rise-storage id="cache-folder-invalid" companyId="abc123" folder="images" fileType="video"></rise-storage>
 
   <script src="../js/rise-storage-data.js"></script>
   <script>
@@ -22,6 +23,7 @@
         clock,
         cacheFolder = document.querySelector("#cache-folder"),
         cacheFile = document.querySelector("#cache-file"),
+        invalidFolder = document.querySelector("#cache-folder-invalid"),
         suffix = "?alt=media";
 
       suiteSetup(function() {
@@ -209,6 +211,15 @@
         test("should correctly request for first item in folder file list", function () {
           cacheFolder._getFilesFromCache(images);
           assert(spy.calledWith(images.files[1]));
+        });
+
+        test("should fire rise-storage-folder-invalid if no valid files exist in folder", function() {
+          var errorSpy = sinon.spy();
+
+          invalidFolder.addEventListener("rise-storage-folder-invalid", errorSpy);
+          invalidFolder._handleStorageFolder(images);
+
+          assert(errorSpy.calledOnce);
         });
 
       });

--- a/test/unit/rise-storage.html
+++ b/test/unit/rise-storage.html
@@ -18,6 +18,7 @@
   <rise-storage id="file-folder" companyId="abc123" folder="images" fileName="home.jpg"></rise-storage>
   <rise-storage id="file-bucket" companyId="abc123" fileName="home.jpg"></rise-storage>
   <rise-storage id="content-type" companyId="abc123" folder="images" contentType="image/jpeg image/png"></rise-storage>
+  <rise-storage id="invalid-folder" companyId="abc123" folder="images" fileType="video"></rise-storage>
 
   <script src="../js/rise-storage-data.js"></script>
   <script>
@@ -28,6 +29,7 @@
         noCompany = document.querySelector("#noCompany"),
         bucket = document.querySelector("#bucket"),
         folder = document.querySelector("#folder"),
+        invalidFolder = document.querySelector("#invalid-folder"),
         folderTesting = document.querySelector("#folder-testing"),
         fileFolder = document.querySelector("#file-folder"),
         fileBucket = document.querySelector("#file-bucket"),
@@ -310,6 +312,7 @@
 
         suiteSetup(function () {
           folder._reset();
+          invalidFolder._reset();
           localImages = JSON.parse(JSON.stringify(images));
         });
 
@@ -422,6 +425,15 @@
           assert.isTrue(responded);
           images.files[2].etag = "CMiEudSn2MMCEAs=";
           done();
+        });
+
+        test("should fire rise-storage-folder-invalid if no valid files exist in folder", function() {
+          var errorSpy = sinon.spy();
+
+          invalidFolder.addEventListener("rise-storage-folder-invalid", errorSpy);
+          invalidFolder._handleStorageFolder(images);
+
+          assert(errorSpy.calledOnce);
         });
       });
 


### PR DESCRIPTION
- Firing "rise-storage-invalid-formats" event when folder only contains files of the wrong file type format, in both scenarios of Rise Cache running and not running
- Adding test coverage
- Minor version patch bump
- README updated to include new event