### PR TITLE
Adding event to indicate an error with Storage API

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,9 @@ The web component returns a JSON response for each file matching the provided cr
 | `rise-storage-empty-folder`   | Fired when the request is for a folder that is empty.               |
 | `rise-storage-no-folder`      | Fired when the request is for a folder that does not exist.         |
 | `rise-storage-no-file`        | Fired when the request is for a file that does not exist.           |
-| `rise-storage-file-throttled` | Fired when the request is for a file that has been throttled.       |
-| `rise-storage-folder-invalid`| Fired when the request is for a folder that only contains files of the wrong file type format.     
+| `rise-storage-file-throttled` | Fired when the request is for a file that has been throttled.
+| `rise-storage-folder-invalid` | Fired when the request is for a folder that only contains files of the wrong file type format.
+| `rise-storage-api-error`      | Fired when the request returns a response indicating an error with the Storage API.     
 
 
 ### Methods

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "authors": [
     "Donna Peplinskie <donna.peplinskie@risevision.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-component-rise-storage",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "The Rise Storage Web Component uses Google’s storage API to retrieve the URLs of all files in a particular folder, or the URL of a single file in a particular folder, from Rise Storage.",
   "scripts": {
     "test": "gulp test",

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -410,7 +410,10 @@
      */
     _processStorageResponse: function(e, resp) {
       if (resp && resp.response) {
-        if (this._isEmptyFolder(resp.response)) {
+        if (this._isAPIError(resp.response)) {
+          this.fire("rise-storage-api-error", resp.response);
+        }
+        else if (this._isEmptyFolder(resp.response)) {
           this.fire("rise-storage-empty-folder");
         }
         else if (this._noFolderExists(resp.response)) {
@@ -1008,6 +1011,13 @@
           this._loadStorage();
         }, this.refresh * 60000);
       }
+    },
+
+    /**
+     * Checks if the request has responded with a storage api error.
+     */
+    _isAPIError: function (resp) {
+      return (resp.code !== 200 && !resp.result);
     },
 
     /**

--- a/test/integration/offline-player.html
+++ b/test/integration/offline-player.html
@@ -141,6 +141,8 @@
 
         test("should send a rise-storage-response event after receiving a response updated notification", function(done) {
           var storageResponse = {
+            result: true,
+            code: 200,
             files: [{
               name: "images/image.jpg",
               selfLink: "https://storage.googleapis.com/risemedialibrary-abc123/images%2Fimage.jpg",

--- a/test/integration/rise-storage.html
+++ b/test/integration/rise-storage.html
@@ -290,6 +290,39 @@
         });
       });
 
+      suite("rise-storage-api-error", function() {
+        setup(function() {
+          file._reset();
+          file._isCacheRunning = false;
+          file._pingReceived = true;
+        });
+
+        test("should fire rise-storage-api-error if storage response indicates an error", function(done) {
+          responseHandler = function(response) {
+            assert.isObject(response.detail, "response.detail is a response object");
+
+            file.removeEventListener("rise-storage-api-error", responseHandler);
+
+            done();
+          };
+
+          file.addEventListener("rise-storage-api-error", responseHandler);
+          server.respondWith([200, header, JSON.stringify(apiError)]);
+          file.go();
+        });
+
+        test("should not fire rise-storage-api-error if storage response doesn't indicate an error", function(done) {
+          responseHandler = sinon.spy();
+
+          file.addEventListener("rise-storage-api-error", responseHandler);
+          server.respondWith([200, header, JSON.stringify(bucketImage)]);
+          file.go();
+
+          assert(responseHandler.notCalled);
+          done();
+        });
+      });
+
       suite("rise-storage-empty-folder", function() {
         setup(function() {
           folder._reset();

--- a/test/js/rise-storage-data.js
+++ b/test/js/rise-storage-data.js
@@ -1,5 +1,7 @@
 var header = { "Content-Type": "text/json" },
   images = {
+    "result": true,
+    "code": 200,
     "files": [{
       "name": "images/",
       "contentType": "text/plain",
@@ -34,6 +36,8 @@ var header = { "Content-Type": "text/json" },
     }]
   },
   mixedMedia = {
+    "result": true,
+    "code": 200,
     "files": [{
       "name": "images/",
       "contentType": "text/plain",
@@ -108,6 +112,8 @@ var header = { "Content-Type": "text/json" },
     }]
   },
   folderImage = {
+    "result": true,
+    "code": 200,
     "files": [{
       "name": "images/home.jpg",
       "contentType": "image/jpeg",
@@ -203,5 +209,10 @@ var header = { "Content-Type": "text/json" },
     "bucketExists": true,
     "kind": "storage#filesItem",
     "etag": "\"-xn2BkoYzbrr0EhwVLI1-3fTi7c/1Ev8FzsCppGm6uDNrJyFySGIKrI\""
+  },
+  apiError = {
+    "result": false,
+    "code": 500,
+    "message": "Could not retrieve Bucket Items"
   },
   xhr, requests;

--- a/test/unit/rise-storage.html
+++ b/test/unit/rise-storage.html
@@ -539,6 +539,16 @@
           assert.equal(folder._isFile, false);
         });
       });
+
+      suite("_isAPIError", function() {
+        test("should return true for an api error response", function() {
+          assert.isTrue(fileBucket._isAPIError(apiError));
+        });
+
+        test("should return false when not an api error response", function() {
+          assert.isFalse(fileBucket._isAPIError(bucketImage));
+        });
+      });
     });
   </script>
 </body>


### PR DESCRIPTION
- Processing a storage response now starts with identifying a potential storage api error before proceeding with further logic and fires "rise-storage-api-error" if there has been an error
- Test data revised and tests added
- README updated to include new "rise-storage-api-error"
- Feature version bump