### PR TITLE
Changed to fall back to Location header for single file

### DIFF
--- a/rise-storage.html
+++ b/rise-storage.html
@@ -836,7 +836,11 @@
 
       if (resp && resp.xhr) {
         lastModified = resp.xhr.getResponseHeader("Last-Modified");
-        file.url = this._cacheUrl;
+        file.url = resp.xhr.responseURL;
+        // Fallback to browsers that does not support responseURL.
+        if(!file.url){
+          file.url = resp.xhr.getResponseHeader("Location");
+        }
 
         if (this._isLoading) {
           // Save Last Modified so it can be compared in subsequent requests.

--- a/test/integration/rise-cache.html
+++ b/test/integration/rise-cache.html
@@ -24,8 +24,11 @@
         responseHandler,
         cacheFile = document.querySelector("#cache-file"),
         cacheFileFolder = document.querySelector("#cache-file-folder"),
-        cacheHeader = { "Last-Modified": "Fri, 01 May 2015 15:32:11 GMT" },
-        newCacheHeader = { "Last-Modified": "Fri, 24 Apr 2015 15:32:11 GMT" };
+        cacheHeader = { "Last-Modified": "Fri, 01 May 2015 15:32:11 GMT", "Location": "//localhost:9494/?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fhome.jpg" },
+        cacheHeaderFolder = { "Last-Modified": "Fri, 01 May 2015 15:32:11 GMT", "Location": "//localhost:9494/?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fimages%252Fhome.jpg" },
+        newCacheHeader = { "Last-Modified": "Fri, 24 Apr 2015 15:32:11 GMT", "Location": "//localhost:9494/cb=0?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fhome.jpg" };
+        newCacheHeaderFolder = { "Last-Modified": "Fri, 24 Apr 2015 15:32:11 GMT", "Location": "//localhost:9494/cb=0?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fimages%252Fhome.jpg" };
+
 
       // Runs for every test
       setup(function () {
@@ -113,7 +116,7 @@
             done();
           };
 
-          server.respondWith([200, cacheHeader, ""]);
+          server.respondWith([200, cacheHeaderFolder, ""]);
           cacheFileFolder.addEventListener("rise-storage-response", responseHandler);
           cacheFileFolder._getFileFromCache();
         });
@@ -125,7 +128,7 @@
           };
 
           cacheFileFolder.addEventListener("rise-storage-response", responseHandler);
-          server.respondWith([200, cacheHeader, ""]);
+          server.respondWith([200, cacheHeaderFolder, ""]);
           cacheFileFolder._getFileFromCache();
         });
 
@@ -138,7 +141,7 @@
           };
 
           cacheFileFolder.addEventListener("rise-storage-response", responseHandler);
-          server.respondWith([200, newCacheHeader, ""]);
+          server.respondWith([200, newCacheHeaderFolder, ""]);
           cacheFileFolder._getFileFromCache();
         });
       });


### PR DESCRIPTION
I had to use Location header on the tests as the sinon fackServer does not have an implementation of the  xhr.responseURL. 

@stulees please review. cheers