### PR TITLE
Don't decode same URL twice

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "authors": [
     "Donna Peplinskie <donna.peplinskie@risevision.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-component-rise-storage",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "The Rise Storage Web Component uses Google’s storage API to retrieve the URLs of all files in a particular folder, or the URL of a single file in a particular folder, from Rise Storage.",
   "scripts": {
     "test": "gulp test",

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -749,7 +749,7 @@
                 }
 
                 previousItem = _.find(self._files, function(obj) {
-                  return obj.name === item.name;
+                  return decodeURIComponent(obj.name) === item.name;
                 });
 
                 // New file
@@ -1095,14 +1095,14 @@
     _processRemovedFiles: function(latestFilesList) {
       function fileExists(file) {
         return latestFilesList.some(function(element) {
-          return file.name === element.name;
+          return decodeURIComponent(file.name) === element.name;
         });
       }
 
-      for(var i = this._files.length - 1; i >= 0; i--) {
+      for (var i = this._files.length - 1; i >= 0; i--) {
         var file = this._files[i];
 
-        if(!fileExists(file)) {
+        if (!fileExists(file)) {
           this._files.splice(i, 1);
           file.deleted = true;
 
@@ -1330,8 +1330,7 @@
         decodedUrl = url.substring(0, end !== -1 ? end : url.length);
       }
 
-      // Decode again to handle double slash encodings
-      return decodeURIComponent(decodedUrl);
+      return decodedUrl;
     },
 
     _loadStorage: function() {

--- a/test/index.html
+++ b/test/index.html
@@ -11,14 +11,14 @@
   <body>
     <script>
       WCT.loadSuites([
-          "integration/rise-storage.html",
-          "integration/rise-cache.html",
-          "integration/offline-player.html",
-          "unit/rise-storage.html",
-          "unit/rise-cache.html",
-          "unit/rise-storage-filter.html",
-          "unit/rise-storage-sort.html",
-          "unit/rise-storage-subscription.html"
+        "integration/rise-storage.html",
+        "integration/rise-cache.html",
+        "integration/offline-player.html",
+        "unit/rise-storage.html",
+        "unit/rise-cache.html",
+        "unit/rise-storage-filter.html",
+        "unit/rise-storage-sort.html",
+        "unit/rise-storage-subscription.html"
       ]);
     </script>
   </body>

--- a/test/integration/rise-cache.html
+++ b/test/integration/rise-cache.html
@@ -111,7 +111,7 @@
         test("should return the correct URL for a specific file in a folder", function(done) {
           responseHandler = function(response) {
             assert.isTrue(response.detail.added);
-            assert.equal(response.detail.name, "images/home.jpg");
+            assert.equal(response.detail.name, "images%2Fhome.jpg");
             assert.equal(response.detail.url, "//localhost:9494/?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fimages%252Fhome.jpg");
             done();
           };
@@ -135,7 +135,7 @@
         test("should return a new URL if the file has changed", function(done) {
           responseHandler = function(response) {
             assert.isTrue(response.detail.changed);
-            assert.equal(response.detail.name, "images/home.jpg");
+            assert.equal(response.detail.name, "images%2Fhome.jpg");
             assert.equal(response.detail.url, "//localhost:9494/cb=0?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fimages%252Fhome.jpg");
             done();
           };

--- a/test/unit/rise-cache.html
+++ b/test/unit/rise-cache.html
@@ -68,9 +68,9 @@
 
             if(files.length === 3) {
               responded = true;
-              assert.equal(files[0].name, "images/home.jpg");
-              assert.equal(files[1].name, "images/circle.png");
-              assert.equal(files[2].name, "images/my-image.bmp");
+              assert.equal(files[0].name, "images%2Fhome.jpg");
+              assert.equal(files[1].name, "images%2Fcircle.png");
+              assert.equal(files[2].name, "images%2Fmy-image.bmp");
               assert.equal(files[0].url, "//localhost:9494/?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fhome.jpg%3Falt%3Dmedia");
               assert.equal(files[1].url, "//localhost:9494/?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fcircle.png%3Falt%3Dmedia");
               assert.equal(files[2].url, "//localhost:9494/?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fmy-image.bmp%3Falt%3Dmedia");
@@ -98,7 +98,7 @@
           listener = function(response) {
             if (response.detail.changed) {
               responded = true;
-              assert.equal(response.detail.name, "images/circle.png");
+              assert.equal(response.detail.name, "images%2Fcircle.png");
               assert.equal(response.detail.url, "//localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fcircle.png%3Falt%3Dmedia");
             }
           };
@@ -115,7 +115,7 @@
           listener = function(response) {
             if (response.detail.added) {
               responded = true;
-              assert.equal(response.detail.name, "images/golf.svg");
+              assert.equal(response.detail.name, "images%2Fgolf.svg");
               assert.equal(response.detail.url, "//localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia");
             }
           };
@@ -138,7 +138,7 @@
           listener = function(response) {
             if (response.detail.deleted) {
               responded = true;
-              assert.equal(response.detail.name, "images/golf.svg");
+              assert.equal(response.detail.name, "images%2Fgolf.svg");
               assert.equal(response.detail.url, "//localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia");
               cacheFolder.removeEventListener("rise-storage-response", listener);
             }
@@ -253,7 +253,7 @@
           listener = function(response) {
             if (response.detail.added) {
               responded = true;
-              assert.equal(response.detail.name, "images/golf.svg");
+              assert.equal(response.detail.name, "images%2Fgolf.svg");
               assert.equal(response.detail.url, "//localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia");
               cacheFile.removeEventListener("rise-storage-response", listener);
             }
@@ -284,7 +284,7 @@
           listener = function(response) {
             if (response.detail.added) {
               responded = true;
-              assert.equal(response.detail.name, "images/golf.svg");
+              assert.equal(response.detail.name, "images%2Fgolf.svg");
               assert.equal(response.detail.url, "//localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia");
               cacheFile.removeEventListener("rise-storage-response", listener);
             }
@@ -316,7 +316,7 @@
           listener = function(response) {
             if (response.detail.added) {
               responded = true;
-              assert.equal(response.detail.name, "images/golf.svg");
+              assert.equal(response.detail.name, "images%2Fgolf.svg");
               assert.equal(response.detail.url, "//localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia");
               cacheFile.removeEventListener("rise-storage-response", listener);
             }
@@ -351,7 +351,7 @@
           listener = function(response) {
             if (response.detail.added) {
               responded = true;
-              assert.equal(response.detail.name, "images/golf.svg");
+              assert.equal(response.detail.name, "images%2Fgolf.svg");
               assert.equal(response.detail.url, "//localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia");
               cacheFolder.removeEventListener("rise-storage-response", listener);
             }


### PR DESCRIPTION
The URL was being decoded twice and was introduced by PR #52. It's unclear as to why this was added in the first place, but just something to be aware of.

Fix for issue #94.