### PR TITLE
Appending `mode` param to file urls when RC not running

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.11.4",
+  "version": "1.12.0",
   "authors": [
     "Donna Peplinskie <donna.peplinskie@risevision.com>"
   ],
@@ -24,6 +24,6 @@
     "underscore": "~1.8.3"
   },
   "devDependencies": {
-    "web-component-tester": "~3.1.3"
+    "web-component-tester": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-component-rise-storage",
-  "version": "1.11.4",
+  "version": "1.12.0",
   "description": "The Rise Storage Web Component uses Google’s storage API to retrieve the URLs of all files in a particular folder, or the URL of a single file in a particular folder, from Rise Storage.",
   "scripts": {
     "test": "gulp test",
@@ -30,6 +30,6 @@
     "gulp-watch": "^1.2.0",
     "jshint-stylish": "^1.0.0",
     "run-sequence": "^1.0.1",
-    "web-component-tester": "^3.1.3"
+    "web-component-tester": "*"
   }
 }

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -679,6 +679,7 @@
         file = {},
         previousItem = null,
         suffix = "?alt=media",
+        modeSuffix = "&mode=preview",
         cb = "&cb=" + new Date().getTime(),
         filesFiltered = 0,
         totalFiles = 0;
@@ -724,7 +725,7 @@
                   file.url = self._baseCacheUrl + "?url=" + encodeURIComponent(item.selfLink + suffix);
                 }
                 else if(!self._isOfflinePlayer()) {
-                  file.url = item.selfLink + suffix;
+                  file.url = item.selfLink + suffix + modeSuffix;
                 }
                 else {
                   file.url = item.selfLink;
@@ -744,7 +745,7 @@
                   file.url = self._baseCacheUrl + "cb=" + new Date().getTime() + "?url=" + encodeURIComponent(item.selfLink + suffix);
                 }
                 else if(!self._isOfflinePlayer()) {
-                  file.url = item.selfLink + suffix + cb;
+                  file.url = item.selfLink + suffix + cb + modeSuffix;
                 }
                 else {
                   file.url = item.selfLink;
@@ -1204,7 +1205,8 @@
         filePath = "",
         startIndex = -1,
         endIndex = -1,
-        suffix = "?alt=media";
+        suffix = "?alt=media",
+        modeSuffix = "&mode=preview";
 
       // File in the root of the bucket.
       if (response.selfLink) {
@@ -1225,7 +1227,7 @@
         this._fileUrl = encodeURIComponent("https://storage.googleapis.com/" + bucket + "/" + filePath);
       }
       else {
-        this._fileUrl = url + suffix;
+        this._fileUrl = url + suffix + modeSuffix;
       }
     },
 

--- a/test/integration/offline-player.html
+++ b/test/integration/offline-player.html
@@ -152,8 +152,8 @@
 
           responseHandler = function(response) {
             assert.equal(response.detail.name, "images/image.jpg");
-            assert.equal(response.detail.url, "https://storage.googleapis.com/risemedialibrary-abc123/images%2Fimage.jpg?alt=media");
-            assert.isTrue(response.detail.url.startsWith("https://storage.googleapis.com/risemedialibrary-abc123/images%2Fimage.jpg?alt=media"));
+            assert.equal(response.detail.url, "https://storage.googleapis.com/risemedialibrary-abc123/images%2Fimage.jpg?alt=media&mode=preview");
+            assert.isTrue(response.detail.url.startsWith("https://storage.googleapis.com/risemedialibrary-abc123/images%2Fimage.jpg?alt=media&mode=preview"));
             done();
           };
 

--- a/test/integration/rise-storage.html
+++ b/test/integration/rise-storage.html
@@ -101,7 +101,7 @@
         test("should return the correct URL for a specific file in a bucket after 24 hours has passed since last check of the subscription status", function(done) {
           responseHandler = function(response) {
             assert.equal(response.detail.name, "home.jpg");
-            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media");
+            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media&mode=preview");
             done();
           };
 
@@ -116,7 +116,7 @@
         test("should return the correct URL for a specific file in a bucket", function(done) {
           responseHandler = function(response) {
             assert.equal(response.detail.name, "home.jpg");
-            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media");
+            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media&mode=preview");
             done();
           };
 
@@ -140,7 +140,7 @@
           responseHandler = function(response) {
             assert.isTrue(response.detail.changed);
             assert.equal(response.detail.name, "home.jpg");
-            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media&cb=0");
+            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media&mode=preview&cb=0");
             done();
           };
 
@@ -171,7 +171,7 @@
         test("should return the correct URL for a specific file in a folder", function(done) {
           responseHandler = function(response) {
             assert.equal(response.detail.name, "images/home.jpg");
-            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
+            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=preview");
             done();
           };
 
@@ -194,7 +194,7 @@
         test("should return a new URL if the file has changed", function(done) {
           responseHandler = function(response) {
             assert.isTrue(response.detail.changed);
-            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&cb=0");
+            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=preview&cb=0");
             done();
           };
 
@@ -232,9 +232,9 @@
               assert.equal(files[0].name, "images/home.jpg");
               assert.equal(files[1].name, "images/circle.png");
               assert.equal(files[2].name, "images/my-image.bmp");
-              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
-              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media");
-              assert.equal(files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media");
+              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=preview");
+              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&mode=preview");
+              assert.equal(files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media&mode=preview");
               done();
             }
           };
@@ -265,7 +265,7 @@
           responseHandler = function(response) {
             if (response.detail.changed) {
               assert.equal(response.detail.name, "images/circle.png");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&cb=0");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&cb=0&mode=preview");
               done();
             }
           };
@@ -285,7 +285,7 @@
 
             if (response.detail.added && count > 3) {
               assert.equal(response.detail.name, "images/golf.svg");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&cb=0");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&cb=0&mode=preview");
               done();
             }
           };
@@ -307,7 +307,7 @@
           responseHandler = function(response) {
             if (response.detail.deleted) {
               assert.equal(response.detail.name, "images/golf.svg");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&cb=0");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&cb=0&mode=preview");
               done();
             }
           };
@@ -613,7 +613,7 @@
         test("should fire rise-storage-file-throttled if bucket file is throttled", function(done) {
           responseHandler = function(response) {
             assert.isString(response.detail, "response.detail is a string");
-            assert.equal(response.detail, bucketImage.files[0].selfLink + "?alt=media");
+            assert.equal(response.detail, bucketImage.files[0].selfLink + "?alt=media&mode=preview");
 
             file.removeEventListener("rise-storage-file-throttled", responseHandler);
 
@@ -630,7 +630,7 @@
         test("should fire rise-storage-file-throttled if folder file is throttled", function(done) {
           responseHandler = function(response) {
             assert.isString(response.detail, "response.detail is a string");
-            assert.equal(response.detail, folderImage.files[0].selfLink + "?alt=media");
+            assert.equal(response.detail, folderImage.files[0].selfLink + "?alt=media&mode=preview");
 
             fileFolder.removeEventListener("rise-storage-file-throttled", responseHandler);
 
@@ -753,8 +753,8 @@
             if(files.length === 2) {
               assert.equal(files[0].name, "images/home.jpg");
               assert.equal(files[1].name, "images/my-image.bmp");
-              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
-              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media");
+              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=preview");
+              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media&mode=preview");
               done();
             }
           };

--- a/test/unit/rise-cache.html
+++ b/test/unit/rise-cache.html
@@ -24,7 +24,8 @@
         cacheFolder = document.querySelector("#cache-folder"),
         cacheFile = document.querySelector("#cache-file"),
         invalidFolder = document.querySelector("#cache-folder-invalid"),
-        suffix = "?alt=media";
+        suffix = "?alt=media",
+        modeSuffix = "&mode=preview";
 
       suiteSetup(function() {
         xhr = sinon.useFakeXMLHttpRequest();
@@ -502,13 +503,13 @@
         test("should correctly set fileUrl for a file in the root of the bucket when Rise Cache is not running", function() {
           cacheFile._isCacheRunning = false;
           cacheFile._setFileUrl(bucketImage);
-          assert.equal(cacheFile._fileUrl, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg" + suffix);
+          assert.equal(cacheFile._fileUrl, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg" + suffix + modeSuffix);
         });
 
         test("should correctly set fileUrl for a file in a folder when Rise Cache is not running", function() {
           cacheFolder._isCacheRunning = false;
           cacheFolder._setFileUrl(folderImage);
-          assert.equal(cacheFolder._fileUrl, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg" + suffix);
+          assert.equal(cacheFolder._fileUrl, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg" + suffix + modeSuffix);
         });
       });
     });

--- a/test/unit/rise-storage.html
+++ b/test/unit/rise-storage.html
@@ -34,7 +34,8 @@
         fileFolder = document.querySelector("#file-folder"),
         fileBucket = document.querySelector("#file-bucket"),
         contentType = document.querySelector("#content-type"),
-        suffix = "?alt=media";
+        suffix = "?alt=media",
+        modeSuffix = "&mode=preview";
 
       suiteSetup(function() {
         xhr = sinon.useFakeXMLHttpRequest();
@@ -225,11 +226,11 @@
             listener = function(response) {
               responded = true;
               assert.equal(response.detail.name, "home.jpg");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media&mode=preview");
             };
 
             fileBucket.addEventListener("rise-storage-response", listener);
-            fileBucket._fileUrl = url + suffix;
+            fileBucket._fileUrl = url + suffix + modeSuffix;
             fileBucket._handleStorageFile(bucketImage);
 
             assert.isTrue(responded);
@@ -255,7 +256,7 @@
               responded = true;
               assert.isTrue(response.detail.changed);
               assert.equal(response.detail.name, "home.jpg");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media&cb=0");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media&mode=preview&cb=0");
               fileBucket.removeEventListener("rise-storage-response", listener);
             };
 
@@ -355,9 +356,9 @@
               assert.equal(files[0].name, "images/home.jpg");
               assert.equal(files[1].name, "images/circle.png");
               assert.equal(files[2].name, "images/my-image.bmp");
-              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
-              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media");
-              assert.equal(files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media");
+              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=preview");
+              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&mode=preview");
+              assert.equal(files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media&mode=preview");
             }
           };
 
@@ -379,9 +380,9 @@
               assert.equal(files[0].name, "images/home.jpg");
               assert.equal(files[1].name, "images/circle.png");
               assert.equal(files[2].name, "images/my-image.bmp");
-              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
-              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media");
-              assert.equal(files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media");
+              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=preview");
+              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&mode=preview");
+              assert.equal(files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media&mode=preview");
             }
           };
 
@@ -397,7 +398,7 @@
             if (response.detail.changed) {
               responded = true;
               assert.equal(response.detail.name, "images/circle.png");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&cb=0");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&cb=0&mode=preview");
             }
           };
 
@@ -414,7 +415,7 @@
             if (response.detail.added) {
               responded = true;
               assert.equal(response.detail.name, "images/golf.svg");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&cb=0");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&cb=0&mode=preview");
             }
           };
 
@@ -438,7 +439,7 @@
             if (response.detail.deleted) {
               responded = true;
               assert.equal(response.detail.name, "images/golf.svg");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&cb=0");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&cb=0&mode=preview");
             }
           };
 


### PR DESCRIPTION
- Including `mode=preview` to all file url configurations (file and folder files) when RC is not running
- Unit and integration tests revised
- Feature version bump