### PR TITLE
Start refresh timer after firing empty folder event

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "authors": [
     "Donna Peplinskie <donna.peplinskie@risevision.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-component-rise-storage",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "The Rise Storage Web Component uses Google’s storage API to retrieve the URLs of all files in a particular folder, or the URL of a single file in a particular folder, from Rise Storage.",
   "scripts": {
     "test": "gulp test",

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -517,6 +517,7 @@
           }
         }
         else if (this._isEmptyFolder(resp.response)) {
+          this._startTimer();
           this.fire("rise-storage-empty-folder");
         }
         else if (this._noFolderExists(resp.response)) {

--- a/test/integration/rise-storage.html
+++ b/test/integration/rise-storage.html
@@ -392,7 +392,7 @@
           responseHandler = function(response) {
             assert.isObject(response.detail, "response.detail is an object");
             assert.deepEqual(response.detail, {}, "response.detail is an empty object");
-            assert.isTrue(startTimerSpy.calledOnce);
+            assert.isTrue(startTimerSpy.calledOnce, "refresh timer started");
 
             startTimerSpy.restore();
 

--- a/test/integration/rise-storage.html
+++ b/test/integration/rise-storage.html
@@ -387,13 +387,19 @@
         });
 
         test("should fire rise-storage-empty-folder if a folder is empty", function(done) {
+          var startTimerSpy = sinon.spy( folder, "_startTimer" );
+
           responseHandler = function(response) {
             assert.isObject(response.detail, "response.detail is an object");
             assert.deepEqual(response.detail, {}, "response.detail is an empty object");
+            assert.isTrue(startTimerSpy.calledOnce);
+
+            startTimerSpy.restore();
 
             done();
           };
 
+          folder.refresh = 5;
           folder.addEventListener("rise-storage-empty-folder", responseHandler);
           server.respondWith([200, header, JSON.stringify(emptyFolder)]);
           folder.go();


### PR DESCRIPTION
- Ensures a refresh timer will start when scenario of empty folder occurs
- Unit test revised
- Minor patch version bump