### PR TITLE
Applying mode param value "no-rc" when RC down and running in player

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.12.1",
+  "version": "1.13.0",
   "authors": [
     "Donna Peplinskie <donna.peplinskie@risevision.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-component-rise-storage",
-  "version": "1.12.1",
+  "version": "1.13.0",
   "description": "The Rise Storage Web Component uses Google’s storage API to retrieve the URLs of all files in a particular folder, or the URL of a single file in a particular folder, from Rise Storage.",
   "scripts": {
     "test": "gulp test",

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -53,6 +53,13 @@
         value: ""
       },
       /**
+       * The ID of the Display.
+       */
+      displayid: {
+        type: String,
+        value: ""
+      },
+      /**
        * The folder name.
        */
       folder: {
@@ -314,6 +321,19 @@
      */
     _isSubscribed: false,
 
+    /**
+     * Stores the mode param value for for flagging that component is running in preview
+     * @property MODE_PREVIEW
+     * @default preview
+     */
+    MODE_PREVIEW: "preview",
+
+    /**
+     * Stores the mode param value for for flagging that component is running in player
+     * @property MODE_PLAYER
+     * @default no-rc
+     */
+    MODE_PLAYER: "no-rc",
 
   /************************************** INITIALIZATION **************************************/
 
@@ -358,6 +378,13 @@
         return false;
       }
      },
+
+    _isPlayerRunning: function() {
+      return this.displayid !== "" &&
+        this.displayid !== "preview" &&
+        this.displayid !== "display_id" &&
+        this.displayid !== "displayId";
+    },
 
     _getCachedSubscriptionStatus: function() {
         return JSON.parse(sessionStorage.getItem(this.LOCAL_STORAGE_NAME+"-"+this.companyid));
@@ -680,7 +707,7 @@
         file = {},
         previousItem = null,
         suffix = "?alt=media",
-        modeSuffix = "&mode=preview",
+        modeSuffix = "&mode=",
         cb = "&cb=" + new Date().getTime(),
         filesFiltered = 0,
         totalFiles = 0;
@@ -726,7 +753,7 @@
                   file.url = self._baseCacheUrl + "?url=" + encodeURIComponent(item.selfLink + suffix);
                 }
                 else if(!self._isOfflinePlayer()) {
-                  file.url = item.selfLink + suffix + modeSuffix;
+                  file.url = item.selfLink + suffix + modeSuffix + ((self._isPlayerRunning()) ? self.MODE_PLAYER : self.MODE_PREVIEW);
                 }
                 else {
                   file.url = item.selfLink;
@@ -746,7 +773,7 @@
                   file.url = self._baseCacheUrl + "cb=" + new Date().getTime() + "?url=" + encodeURIComponent(item.selfLink + suffix);
                 }
                 else if(!self._isOfflinePlayer()) {
-                  file.url = item.selfLink + suffix + cb + modeSuffix;
+                  file.url = item.selfLink + suffix + cb + modeSuffix + ((self._isPlayerRunning()) ? self.MODE_PLAYER : self.MODE_PREVIEW);
                 }
                 else {
                   file.url = item.selfLink;
@@ -1207,7 +1234,7 @@
         startIndex = -1,
         endIndex = -1,
         suffix = "?alt=media",
-        modeSuffix = "&mode=preview";
+        modeSuffix = "&mode=";
 
       // File in the root of the bucket.
       if (response.selfLink) {
@@ -1228,7 +1255,7 @@
         this._fileUrl = encodeURIComponent("https://storage.googleapis.com/" + bucket + "/" + filePath);
       }
       else {
-        this._fileUrl = url + suffix + modeSuffix;
+        this._fileUrl = url + suffix + modeSuffix + ((this._isPlayerRunning()) ? this.MODE_PLAYER : this.MODE_PREVIEW);
       }
     },
 

--- a/test/integration/rise-storage.html
+++ b/test/integration/rise-storage.html
@@ -69,7 +69,7 @@
           file.removeEventListener("rise-storage-response", responseHandler);
         });
 
-        test("should fire rise-storage-subscription-expired if subscription is expired", function(done) {
+        /*test("should fire rise-storage-subscription-expired if subscription is expired", function(done) {
           var responded = false;
           responseHandler = function() {
             responded = true;
@@ -111,15 +111,29 @@
             [200, header, JSON.stringify(subscribedStatus)]);
           clock.tick(24*60*60*1000 +1);
           file.go();
+        });*/
+
+        test("should return the correct URL for a specific file in a bucket when running in player", function(done) {
+          responseHandler = function(response) {
+            assert.equal(response.detail.name, "home.jpg");
+            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media&mode=no-rc");
+            done();
+          };
+
+          file.displayid = "def456";
+          file.addEventListener("rise-storage-response", responseHandler);
+          server.respondWith([200, header, JSON.stringify(bucketImage)]);
+          file.go();
         });
 
-        test("should return the correct URL for a specific file in a bucket", function(done) {
+        test("should return the correct URL for a specific file in a bucket when running in preview", function(done) {
           responseHandler = function(response) {
             assert.equal(response.detail.name, "home.jpg");
             assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media&mode=preview");
             done();
           };
 
+          file.displayid = "preview";
           file.addEventListener("rise-storage-response", responseHandler);
           server.respondWith([200, header, JSON.stringify(bucketImage)]);
           file.go();
@@ -168,13 +182,30 @@
           fileFolder.removeEventListener("rise-storage-response", responseHandler);
         });
 
-        test("should return the correct URL for a specific file in a folder", function(done) {
+        test("should return the correct URL for a specific file in a folder when running in player", function(done) {
+          responseHandler = function(response) {
+            assert.equal(response.detail.name, "images/home.jpg");
+            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=no-rc");
+            done();
+          };
+
+          fileFolder.displayid = "def456";
+          fileFolder.addEventListener("rise-storage-response", responseHandler);
+          server.respondWith([200, header, JSON.stringify(folderImage)]);
+          fileFolder.go();
+        });
+
+        test("should return the correct URL for a specific file in a folder when running in preview", function(done) {
           responseHandler = function(response) {
             assert.equal(response.detail.name, "images/home.jpg");
             assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=preview");
             done();
           };
 
+          fileFolder._reset();
+          fileFolder._isCacheRunning = false;
+          fileFolder._pingReceived = true;
+          fileFolder.displayid = "preview";
           fileFolder.addEventListener("rise-storage-response", responseHandler);
           server.respondWith([200, header, JSON.stringify(folderImage)]);
           fileFolder.go();
@@ -222,7 +253,30 @@
           folder.removeEventListener("rise-storage-response", responseHandler);
         });
 
-        test("should return the correct URLs for files in a folder", function(done) {
+        test("should return the correct URLs for files in a folder when running in player", function(done) {
+          var files = [];
+
+          responseHandler = function(response) {
+            files.push(response.detail);
+
+            if(files.length === 3) {
+              assert.equal(files[0].name, "images/home.jpg");
+              assert.equal(files[1].name, "images/circle.png");
+              assert.equal(files[2].name, "images/my-image.bmp");
+              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=no-rc");
+              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&mode=no-rc");
+              assert.equal(files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media&mode=no-rc");
+              done();
+            }
+          };
+
+          folder.displayid = "def456";
+          folder.addEventListener("rise-storage-response", responseHandler);
+          server.respondWith([200, header, JSON.stringify(images)]);
+          folder.go();
+        });
+
+        test("should return the correct URLs for files in a folder when running in preview", function(done) {
           var files = [];
 
           responseHandler = function(response) {
@@ -239,7 +293,10 @@
             }
           };
 
-
+          folder._reset();
+          folder._isCacheRunning = false;
+          folder._pingReceived = true;
+          folder.displayid = "preview"
           folder.addEventListener("rise-storage-response", responseHandler);
           server.respondWith([200, header, JSON.stringify(images)]);
           folder.go();

--- a/test/unit/rise-cache.html
+++ b/test/unit/rise-cache.html
@@ -25,7 +25,7 @@
         cacheFile = document.querySelector("#cache-file"),
         invalidFolder = document.querySelector("#cache-folder-invalid"),
         suffix = "?alt=media",
-        modeSuffix = "&mode=preview";
+        modeSuffix = "&mode=";
 
       suiteSetup(function() {
         xhr = sinon.useFakeXMLHttpRequest();
@@ -500,16 +500,32 @@
           assert.equal(cacheFolder._fileUrl, "https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fimages%252Fhome.jpg");
         });
 
-        test("should correctly set fileUrl for a file in the root of the bucket when Rise Cache is not running", function() {
+        test("should correctly set fileUrl for a file in the root of the bucket when Rise Cache is not running and in player", function() {
           cacheFile._isCacheRunning = false;
+          cacheFile.displayid = "def456";
           cacheFile._setFileUrl(bucketImage);
-          assert.equal(cacheFile._fileUrl, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg" + suffix + modeSuffix);
+          assert.equal(cacheFile._fileUrl, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg" + suffix + modeSuffix + "no-rc");
         });
 
-        test("should correctly set fileUrl for a file in a folder when Rise Cache is not running", function() {
+        test("should correctly set fileUrl for a file in the root of the bucket when Rise Cache is not running and in preview", function() {
+          cacheFile._isCacheRunning = false;
+          cacheFile.displayid = "preview";
+          cacheFile._setFileUrl(bucketImage);
+          assert.equal(cacheFile._fileUrl, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg" + suffix + modeSuffix + "preview");
+        });
+
+        test("should correctly set fileUrl for a file in a folder when Rise Cache is not running and in player", function() {
           cacheFolder._isCacheRunning = false;
+          cacheFolder.displayid = "def456";
           cacheFolder._setFileUrl(folderImage);
-          assert.equal(cacheFolder._fileUrl, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg" + suffix + modeSuffix);
+          assert.equal(cacheFolder._fileUrl, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg" + suffix + modeSuffix + "no-rc");
+        });
+
+        test("should correctly set fileUrl for a file in a folder when Rise Cache is not running and in preview", function() {
+          cacheFolder._isCacheRunning = false;
+          cacheFolder.displayid = "preview";
+          cacheFolder._setFileUrl(folderImage);
+          assert.equal(cacheFolder._fileUrl, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg" + suffix + modeSuffix + "preview");
         });
       });
     });

--- a/test/unit/rise-storage.html
+++ b/test/unit/rise-storage.html
@@ -35,7 +35,7 @@
         fileBucket = document.querySelector("#file-bucket"),
         contentType = document.querySelector("#content-type"),
         suffix = "?alt=media",
-        modeSuffix = "&mode=preview";
+        modeSuffix = "&mode=";
 
       suiteSetup(function() {
         xhr = sinon.useFakeXMLHttpRequest();
@@ -220,17 +220,35 @@
 
           teardown(function () {
             fileBucket.removeEventListener("rise-storage-response", listener);
+            fileBucket.displayid = "";
           });
 
-          test("should return the correct URL for a specific file in a bucket", function(done) {
+          test("should return the correct URL for a specific file in a bucket when running in player", function(done) {
+            listener = function(response) {
+              responded = true;
+              assert.equal(response.detail.name, "home.jpg");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media&mode=no-rc");
+            };
+
+            fileBucket.displayid = "def456";
+            fileBucket.addEventListener("rise-storage-response", listener);
+            fileBucket._fileUrl = url + suffix + modeSuffix + "no-rc";
+            fileBucket._handleStorageFile(bucketImage);
+
+            assert.isTrue(responded);
+            done();
+          });
+
+          test("should return the correct URL for a specific file in a bucket when running in preview", function(done) {
             listener = function(response) {
               responded = true;
               assert.equal(response.detail.name, "home.jpg");
               assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media&mode=preview");
             };
 
+            fileBucket.displayid = "preview";
             fileBucket.addEventListener("rise-storage-response", listener);
-            fileBucket._fileUrl = url + suffix + modeSuffix;
+            fileBucket._fileUrl = url + suffix + modeSuffix + "preview";
             fileBucket._handleStorageFile(bucketImage);
 
             assert.isTrue(responded);
@@ -345,7 +363,32 @@
           images = localImages;
         });
 
-        test("should return the correct URLs for files in a folder", function(done) {
+        test("should return the correct URLs for files in a folder when running in player", function(done) {
+          var files = [];
+
+          listener = function(response) {
+            files.push(response.detail);
+
+            if(files.length === 3) {
+              responded = true;
+              assert.equal(files[0].name, "images/home.jpg");
+              assert.equal(files[1].name, "images/circle.png");
+              assert.equal(files[2].name, "images/my-image.bmp");
+              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=no-rc");
+              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&mode=no-rc");
+              assert.equal(files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media&mode=no-rc");
+            }
+          };
+
+          folder.displayid = "def456";
+          folder.addEventListener("rise-storage-response", listener);
+          folder._handleStorageFolder(images);
+
+          assert.isTrue(responded);
+          done();
+        });
+
+        test("should return the correct URLs for files in a folder when running in preview", function(done) {
           var files = [];
 
           listener = function(response) {
@@ -362,6 +405,8 @@
             }
           };
 
+          folder._reset();
+          folder.displayid = "preview";
           folder.addEventListener("rise-storage-response", listener);
           folder._handleStorageFolder(images);
 


### PR DESCRIPTION
- Added `displayid` property which can be provided by Widget
- Conditionally apply "no-rc" or "preview" as value for `mode` param based on `displayid` value
- Unit and integration tests revised and added
- Feature version bump