### PR TITLE
Add env verifier params to applicable file urls

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Description
+Include a summary of the change. If this is fixing a defect, ensure to link to the issue this is fixing.
+
+## Motivation and Context
+Why is this change required? What problem does it solve?
+
+## How Has This Been Tested?
+Describe in detail how you tested your changes. Include details of your testing environment and link(s) for reviewers to validate.
+
+## Release Plan:
+- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed.
+- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed
+
+#### Release Checklist Items Skipped?
+If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "authors": [
     "Donna Peplinskie <donna.peplinskie@risevision.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-component-rise-storage",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "The Rise Storage Web Component uses Google’s storage API to retrieve the URLs of all files in a particular folder, or the URL of a single file in a particular folder, from Rise Storage.",
   "scripts": {
     "test": "gulp test",
@@ -31,6 +31,6 @@
     "gulp-watch": "^1.2.0",
     "jshint-stylish": "^1.0.0",
     "run-sequence": "^1.0.1",
-    "web-component-tester": "*"
+    "web-component-tester": "5.0.2"
   }
 }

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -116,6 +116,14 @@
       env: {
         type: String,
         value: "prod"
+      },
+      endpointtype: {
+        type: String,
+        value :""
+      },
+      viewerid: {
+        type: String,
+        value: ""
       }
     },
 
@@ -709,6 +717,8 @@
         suffix = "?alt=media",
         modeSuffix = "&mode=",
         displayIdSuffix = "&displayid=" + this.displayid,
+        endpointSuffix = "&env=" + this.endpointtype,
+        viewerIdSuffix = "&viewerId=" + this.viewerid,
         cb = "&cb=" + new Date().getTime(),
         filesFiltered = 0,
         totalFiles = 0;
@@ -754,7 +764,7 @@
                   file.url = self._baseCacheUrl + "?url=" + encodeURIComponent(item.selfLink + suffix);
                 }
                 else if(!self._isOfflinePlayer()) {
-                  file.url = item.selfLink + suffix + modeSuffix + ((self._isPlayerRunning()) ? self.MODE_PLAYER : self.MODE_PREVIEW) + displayIdSuffix;
+                  file.url = item.selfLink + suffix + modeSuffix + ((self._isPlayerRunning()) ? self.MODE_PLAYER : self.MODE_PREVIEW + endpointSuffix + viewerIdSuffix) + displayIdSuffix;
                 }
                 else {
                   file.url = item.selfLink;
@@ -774,7 +784,7 @@
                   file.url = self._baseCacheUrl + "cb=" + new Date().getTime() + "?url=" + encodeURIComponent(item.selfLink + suffix);
                 }
                 else if(!self._isOfflinePlayer()) {
-                  file.url = item.selfLink + suffix + cb + modeSuffix + ((self._isPlayerRunning()) ? self.MODE_PLAYER : self.MODE_PREVIEW) + displayIdSuffix;
+                  file.url = item.selfLink + suffix + cb + modeSuffix + ((self._isPlayerRunning()) ? self.MODE_PLAYER : self.MODE_PREVIEW + endpointSuffix + viewerIdSuffix) + displayIdSuffix;
                 }
                 else {
                   file.url = item.selfLink;
@@ -1236,7 +1246,9 @@
         endIndex = -1,
         suffix = "?alt=media",
         modeSuffix = "&mode=",
-        displayIdSuffix = "&displayid=" + this.displayid;
+        displayIdSuffix = "&displayid=" + this.displayid,
+        endpointSuffix = "&env=" + this.endpointtype,
+        viewerIdSuffix = "&viewerId=" + this.viewerid;
 
       // File in the root of the bucket.
       if (response.selfLink) {
@@ -1257,7 +1269,7 @@
         this._fileUrl = encodeURIComponent("https://storage.googleapis.com/" + bucket + "/" + filePath);
       }
       else {
-        this._fileUrl = url + suffix + modeSuffix + ((this._isPlayerRunning()) ? this.MODE_PLAYER : this.MODE_PREVIEW) + displayIdSuffix;
+        this._fileUrl = url + suffix + modeSuffix + ((this._isPlayerRunning()) ? this.MODE_PLAYER : this.MODE_PREVIEW + endpointSuffix + viewerIdSuffix) + displayIdSuffix;
       }
     },
 

--- a/test/integration/offline-player.html
+++ b/test/integration/offline-player.html
@@ -152,8 +152,8 @@
 
           responseHandler = function(response) {
             assert.equal(response.detail.name, "images/image.jpg");
-            assert.equal(response.detail.url, "https://storage.googleapis.com/risemedialibrary-abc123/images%2Fimage.jpg?alt=media&mode=preview&displayid=preview");
-            assert.isTrue(response.detail.url.startsWith("https://storage.googleapis.com/risemedialibrary-abc123/images%2Fimage.jpg?alt=media&mode=preview&displayid=preview"));
+            assert.equal(response.detail.url, "https://storage.googleapis.com/risemedialibrary-abc123/images%2Fimage.jpg?alt=media&mode=preview&env=&viewerId=&displayid=preview");
+            assert.isTrue(response.detail.url.startsWith("https://storage.googleapis.com/risemedialibrary-abc123/images%2Fimage.jpg?alt=media&mode=preview&env=&viewerId=&displayid=preview"));
             done();
           };
 

--- a/test/integration/rise-storage.html
+++ b/test/integration/rise-storage.html
@@ -129,7 +129,7 @@
         test("should return the correct URL for a specific file in a bucket when running in preview", function(done) {
           responseHandler = function(response) {
             assert.equal(response.detail.name, "home.jpg");
-            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media&mode=preview&displayid=preview");
+            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media&mode=preview&env=&viewerId=&displayid=preview");
             done();
           };
 
@@ -154,7 +154,7 @@
           responseHandler = function(response) {
             assert.isTrue(response.detail.changed);
             assert.equal(response.detail.name, "home.jpg");
-            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media&mode=preview&displayid=preview&cb=0");
+            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media&mode=preview&env=&viewerId=&displayid=preview&cb=0");
             done();
           };
 
@@ -198,7 +198,7 @@
         test("should return the correct URL for a specific file in a folder when running in preview", function(done) {
           responseHandler = function(response) {
             assert.equal(response.detail.name, "images/home.jpg");
-            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=preview&displayid=preview");
+            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=preview&env=&viewerId=&displayid=preview");
             done();
           };
 
@@ -225,7 +225,7 @@
         test("should return a new URL if the file has changed", function(done) {
           responseHandler = function(response) {
             assert.isTrue(response.detail.changed);
-            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=preview&displayid=preview&cb=0");
+            assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=preview&env=&viewerId=&displayid=preview&cb=0");
             done();
           };
 
@@ -286,9 +286,9 @@
               assert.equal(files[0].name, "images/home.jpg");
               assert.equal(files[1].name, "images/circle.png");
               assert.equal(files[2].name, "images/my-image.bmp");
-              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=preview&displayid=preview");
-              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&mode=preview&displayid=preview");
-              assert.equal(files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media&mode=preview&displayid=preview");
+              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=preview&env=&viewerId=&displayid=preview");
+              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&mode=preview&env=&viewerId=&displayid=preview");
+              assert.equal(files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media&mode=preview&env=&viewerId=&displayid=preview");
               done();
             }
           };
@@ -322,7 +322,7 @@
           responseHandler = function(response) {
             if (response.detail.changed) {
               assert.equal(response.detail.name, "images/circle.png");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&cb=0&mode=preview&displayid=preview");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&cb=0&mode=preview&env=&viewerId=&displayid=preview");
               done();
             }
           };
@@ -342,7 +342,7 @@
 
             if (response.detail.added && count > 3) {
               assert.equal(response.detail.name, "images/golf.svg");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&cb=0&mode=preview&displayid=preview");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&cb=0&mode=preview&env=&viewerId=&displayid=preview");
               done();
             }
           };
@@ -364,7 +364,7 @@
           responseHandler = function(response) {
             if (response.detail.deleted) {
               assert.equal(response.detail.name, "images/golf.svg");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&cb=0&mode=preview&displayid=preview");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&cb=0&mode=preview&env=&viewerId=&displayid=preview");
               done();
             }
           };
@@ -676,7 +676,7 @@
         test("should fire rise-storage-file-throttled if bucket file is throttled", function(done) {
           responseHandler = function(response) {
             assert.isString(response.detail, "response.detail is a string");
-            assert.equal(response.detail, bucketImage.files[0].selfLink + "?alt=media&mode=preview&displayid=preview");
+            assert.equal(response.detail, bucketImage.files[0].selfLink + "?alt=media&mode=preview&env=&viewerId=&displayid=preview");
 
             file.removeEventListener("rise-storage-file-throttled", responseHandler);
 
@@ -693,7 +693,7 @@
         test("should fire rise-storage-file-throttled if folder file is throttled", function(done) {
           responseHandler = function(response) {
             assert.isString(response.detail, "response.detail is a string");
-            assert.equal(response.detail, folderImage.files[0].selfLink + "?alt=media&mode=preview&displayid=preview");
+            assert.equal(response.detail, folderImage.files[0].selfLink + "?alt=media&mode=preview&env=&viewerId=&displayid=preview");
 
             fileFolder.removeEventListener("rise-storage-file-throttled", responseHandler);
 
@@ -816,8 +816,8 @@
             if(files.length === 2) {
               assert.equal(files[0].name, "images/home.jpg");
               assert.equal(files[1].name, "images/my-image.bmp");
-              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=preview&displayid=preview");
-              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media&mode=preview&displayid=preview");
+              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=preview&env=&viewerId=&displayid=preview");
+              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media&mode=preview&env=&viewerId=&displayid=preview");
               done();
             }
           };

--- a/test/unit/rise-cache.html
+++ b/test/unit/rise-cache.html
@@ -26,7 +26,9 @@
         invalidFolder = document.querySelector("#cache-folder-invalid"),
         suffix = "?alt=media",
         modeSuffix = "&mode=",
-        displayIdSuffix = "&displayid=";
+        displayIdSuffix = "&displayid=",
+        endpointSuffix = "&env=",
+        viewerIdSuffix = "&viewerId=";
 
       suiteSetup(function() {
         xhr = sinon.useFakeXMLHttpRequest();
@@ -512,7 +514,7 @@
           cacheFile._isCacheRunning = false;
           cacheFile.displayid = "preview";
           cacheFile._setFileUrl(bucketImage);
-          assert.equal(cacheFile._fileUrl, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg" + suffix + modeSuffix + "preview" + displayIdSuffix + "preview");
+          assert.equal(cacheFile._fileUrl, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg" + suffix + modeSuffix + "preview" + endpointSuffix + viewerIdSuffix + displayIdSuffix + "preview");
         });
 
         test("should correctly set fileUrl for a file in a folder when Rise Cache is not running and in player", function() {
@@ -526,7 +528,7 @@
           cacheFolder._isCacheRunning = false;
           cacheFolder.displayid = "preview";
           cacheFolder._setFileUrl(folderImage);
-          assert.equal(cacheFolder._fileUrl, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg" + suffix + modeSuffix + "preview" + displayIdSuffix + "preview");
+          assert.equal(cacheFolder._fileUrl, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg" + suffix + modeSuffix + "preview" + endpointSuffix + viewerIdSuffix +  displayIdSuffix + "preview");
         });
       });
     });

--- a/test/unit/rise-storage.html
+++ b/test/unit/rise-storage.html
@@ -399,9 +399,9 @@
               assert.equal(files[0].name, "images/home.jpg");
               assert.equal(files[1].name, "images/circle.png");
               assert.equal(files[2].name, "images/my-image.bmp");
-              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=preview&displayid=preview");
-              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&mode=preview&displayid=preview");
-              assert.equal(files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media&mode=preview&displayid=preview");
+              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=preview&env=&viewerId=&displayid=preview");
+              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&mode=preview&env=&viewerId=&displayid=preview");
+              assert.equal(files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media&mode=preview&env=&viewerId=&displayid=preview");
             }
           };
 
@@ -425,9 +425,9 @@
               assert.equal(files[0].name, "images/home.jpg");
               assert.equal(files[1].name, "images/circle.png");
               assert.equal(files[2].name, "images/my-image.bmp");
-              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=preview&displayid=preview");
-              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&mode=preview&displayid=preview");
-              assert.equal(files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media&mode=preview&displayid=preview");
+              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=preview&env=&viewerId=&displayid=preview");
+              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&mode=preview&env=&viewerId=&displayid=preview");
+              assert.equal(files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media&mode=preview&env=&viewerId=&displayid=preview");
             }
           };
 
@@ -443,7 +443,7 @@
             if (response.detail.changed) {
               responded = true;
               assert.equal(response.detail.name, "images/circle.png");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&cb=0&mode=preview&displayid=preview");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&cb=0&mode=preview&env=&viewerId=&displayid=preview");
             }
           };
 
@@ -460,7 +460,7 @@
             if (response.detail.added) {
               responded = true;
               assert.equal(response.detail.name, "images/golf.svg");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&cb=0&mode=preview&displayid=preview");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&cb=0&mode=preview&env=&viewerId=&displayid=preview");
             }
           };
 
@@ -484,7 +484,7 @@
             if (response.detail.deleted) {
               responded = true;
               assert.equal(response.detail.name, "images/golf.svg");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&cb=0&mode=preview&displayid=preview");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&cb=0&mode=preview&env=&viewerId=&displayid=preview");
             }
           };
 


### PR DESCRIPTION
## Description
Adding two new properties for setting environment verifier params. 

Ensuring the two params are added to all file urls when determined to be running in preview. 

## Motivation and Context
Data Usage Analysis

## How Has This Been Tested?
Ran test coverage locally and all passed. Manual tests via Widgets are still pending. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
